### PR TITLE
Add interface ICombinatorialValuesProvider which provides values for test method parameters.

### DIFF
--- a/src/Xunit.Combinatorial.Tests/CombinatorialMemberDataTests.cs
+++ b/src/Xunit.Combinatorial.Tests/CombinatorialMemberDataTests.cs
@@ -1,0 +1,38 @@
+﻿namespace Xunit.Combinatorial.Tests
+{
+    using Internal;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class CombinatorialMemberDataTests
+    {
+        public static string[] ArrayProperty => new[] { "A", "b", "C" };
+        public void M_ArrayProperty([CombinatorialMemberData("ArrayProperty")]string s) { }
+
+        public static string[] ArrayField = new[] { "x", "Y", "z" };
+        public void M_ArrayField([CombinatorialMemberData("ArrayField")]string s) { }
+
+
+        [Fact]
+        public void Property_Array()
+        {
+            AssertData(nameof(M_ArrayProperty), ArrayProperty);
+        }
+
+        [Fact]
+        public void Field_Array()
+        {
+            AssertData(nameof(M_ArrayField), ArrayField);
+        }
+
+        private void AssertData(string methodName, IEnumerable<object> expectedData)
+        {
+            var actual = ValuesUtilities.GetValuesFor(this.GetType().GetMethod(methodName).GetParameters()[0]);
+            var expected = new HashSet<object>(expectedData);
+            Assert.True(expected.SetEquals(actual));
+        }
+    }
+}

--- a/src/Xunit.Combinatorial.Tests/SampleUses.cs
+++ b/src/Xunit.Combinatorial.Tests/SampleUses.cs
@@ -32,5 +32,14 @@
             // true  false true
             // true  true  false
         }
+
+        public static object[] _boolValues =  new object[] { 1, 2, 4, 7 };
+
+        [Theory]
+        [CombinatorialData]
+        public void MemberData([CombinatorialMemberData(nameof(_boolValues))]int i)
+        {
+            // it should generate 4 testcases from _boolValues
+        }
     }
 }

--- a/src/Xunit.Combinatorial.Tests/Xunit.Combinatorial.Tests.csproj
+++ b/src/Xunit.Combinatorial.Tests/Xunit.Combinatorial.Tests.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CombinatorialDataAttributeTests.cs" />
+    <Compile Include="CombinatorialMemberDataTests.cs" />
     <Compile Include="CombinatorialValuesAttributeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SampleUses.cs" />

--- a/src/Xunit.Combinatorial/CombinatorialDataAttribute.cs
+++ b/src/Xunit.Combinatorial/CombinatorialDataAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace Xunit
 {
+    using Combinatorial.Internal;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/src/Xunit.Combinatorial/CombinatorialMemberData.cs
+++ b/src/Xunit.Combinatorial/CombinatorialMemberData.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved. Licensed under the Ms-PL.
+
+/* Note: the code was adapted from XUnit - src\xunit.core\MemberDataAttributeBase.cs */
+
+namespace Xunit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    /// <summary>
+    /// Specifies a member which provides the values for the test runs.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class CombinatorialMemberData : Attribute, ICombinatorialValuesProvider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CombinatorialMemberData"/> class.
+        /// </summary>
+        /// <param name="memberName">The name of the public static member on the test class that will provide the test data</param>
+        /// <param name="parameters">The parameters for the member (only supported for methods; ignored for everything else)</param>
+        public CombinatorialMemberData(string memberName, params object[] parameters)
+        {
+            Requires.NotNull(memberName, nameof(memberName));
+
+            this.MemberName = memberName;
+            this.Parameters = parameters;
+        }
+
+        /// <summary>
+        /// Gets the member name.
+        /// </summary>
+        public string MemberName { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the type to retrieve the member from. If not set, then the property will be
+        /// retrieved from the unit test class.
+        /// </summary>
+        public Type MemberType { get; set; }
+
+        /// <summary>
+        /// Gets the parameters passed to the member. Only supported for static methods.
+        /// </summary>
+        public object[] Parameters { get; private set; }
+
+        object[] ICombinatorialValuesProvider.GetValues(ParameterInfo parameter)
+        {
+            var testMethod = parameter.Member;
+            var type = this.MemberType ?? testMethod.DeclaringType;
+            var accessor = this.GetPropertyAccessor(type) ?? this.GetFieldAccessor(type) ?? this.GetMethodAccessor(type);
+            if (accessor == null)
+            {
+                var parameterText = this.Parameters?.Length > 0 ? $" with parameter types: {string.Join(", ", this.Parameters.Select(p => p?.GetType().FullName ?? "(null)"))}" : string.Empty;
+                throw new ArgumentException($"Could not find public static member (property, field, or method) named '{this.MemberName}' on {type.FullName}{parameterText}");
+            }
+
+            var obj = accessor();
+            if (obj == null)
+            {
+                return null;
+            }
+
+            var dataItems = obj as IEnumerable<object>;
+            if (dataItems == null)
+            {
+                throw new ArgumentException($"Property {this.MemberName} on {type.FullName} did not return IEnumerable<object>");
+            }
+
+            return dataItems.ToArray();
+        }
+
+        private static bool ParameterTypesCompatible(ParameterInfo[] parameters, Type[] parameterTypes)
+        {
+            if (parameters?.Length != parameterTypes.Length)
+            {
+                return false;
+            }
+
+            for (int idx = 0; idx < parameters.Length; ++idx)
+            {
+                if (parameterTypes[idx] != null && !parameters[idx].ParameterType.GetTypeInfo().IsAssignableFrom(parameterTypes[idx].GetTypeInfo()))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private Func<object> GetFieldAccessor(Type type)
+        {
+            FieldInfo fieldInfo = null;
+            for (var reflectionType = type; reflectionType != null; reflectionType = reflectionType.GetTypeInfo().BaseType)
+            {
+                fieldInfo = reflectionType.GetRuntimeField(this.MemberName);
+                if (fieldInfo != null)
+                {
+                    break;
+                }
+            }
+
+            if (fieldInfo == null || !fieldInfo.IsStatic)
+            {
+                return null;
+            }
+
+            return () => fieldInfo.GetValue(null);
+        }
+
+        private Func<object> GetMethodAccessor(Type type)
+        {
+            MethodInfo methodInfo = null;
+            var parameterTypes = this.Parameters == null ? new Type[0] : this.Parameters.Select(p => p?.GetType()).ToArray();
+            for (var reflectionType = type; reflectionType != null; reflectionType = reflectionType.GetTypeInfo().BaseType)
+            {
+                methodInfo = reflectionType.GetRuntimeMethods()
+                                           .FirstOrDefault(m => m.Name == this.MemberName && ParameterTypesCompatible(m.GetParameters(), parameterTypes));
+                if (methodInfo != null)
+                {
+                    break;
+                }
+            }
+
+            if (methodInfo == null || !methodInfo.IsStatic)
+            {
+                return null;
+            }
+
+            return () => methodInfo.Invoke(null, this.Parameters);
+        }
+
+        private Func<object> GetPropertyAccessor(Type type)
+        {
+            PropertyInfo propInfo = null;
+            for (var reflectionType = type; reflectionType != null; reflectionType = reflectionType.GetTypeInfo().BaseType)
+            {
+                propInfo = reflectionType.GetRuntimeProperty(this.MemberName);
+                if (propInfo != null)
+                {
+                    break;
+                }
+            }
+
+            if (propInfo == null || propInfo.GetMethod == null || !propInfo.GetMethod.IsStatic)
+            {
+                return null;
+            }
+
+            return () => propInfo.GetValue(null, null);
+        }
+    }
+}

--- a/src/Xunit.Combinatorial/CombinatorialValuesAttribute.cs
+++ b/src/Xunit.Combinatorial/CombinatorialValuesAttribute.cs
@@ -3,12 +3,13 @@
 namespace Xunit
 {
     using System;
+    using System.Reflection;
 
     /// <summary>
     /// Specifies which values for this parameter should be used for running the test method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
-    public class CombinatorialValuesAttribute : Attribute
+    public class CombinatorialValuesAttribute : Attribute, ICombinatorialValuesProvider
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CombinatorialValuesAttribute"/> class.
@@ -26,5 +27,7 @@ namespace Xunit
         /// </summary>
         /// <value>An array of values.</value>
         public object[] Values { get; }
+
+        object[] ICombinatorialValuesProvider.GetValues(ParameterInfo parameter) => this.Values;
     }
 }

--- a/src/Xunit.Combinatorial/ICombinatorialValuesProvider.cs
+++ b/src/Xunit.Combinatorial/ICombinatorialValuesProvider.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved. Licensed under the Ms-PL.
+
+namespace Xunit
+{
+    using System.Reflection;
+
+    /// <summary>
+    /// Specifies which values for this parameter should be used for running the test method.
+    /// </summary>
+    public interface ICombinatorialValuesProvider
+    {
+        /// <summary>
+        /// Gets the values that should be passed to this parameter on the test method.
+        /// </summary>
+        /// <param name="parameter">The parameter for which the values should be provided</param>
+        /// <returns>The values</returns>
+        object[] GetValues(ParameterInfo parameter);
+    }
+}

--- a/src/Xunit.Combinatorial/PairwiseDataAttribute.cs
+++ b/src/Xunit.Combinatorial/PairwiseDataAttribute.cs
@@ -9,6 +9,7 @@ namespace Xunit
     using System.Text;
     using System.Threading.Tasks;
     using Sdk;
+    using Combinatorial.Internal;
 
     /// <summary>
     /// Provides a test method decorated with a <see cref="TheoryAttribute"/>

--- a/src/Xunit.Combinatorial/ValuesUtilities.cs
+++ b/src/Xunit.Combinatorial/ValuesUtilities.cs
@@ -1,29 +1,31 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved. Licensed under the Ms-PL.
 
-namespace Xunit
+namespace Xunit.Combinatorial.Internal
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
 
     /// <summary>
     /// Utility methods for generating values for test parameters.
     /// </summary>
-    internal static class ValuesUtilities
+    public static class ValuesUtilities
     {
         /// <summary>
         /// Gets a sequence of values that should be tested for the specified parameter.
         /// </summary>
         /// <param name="parameter">The parameter to get possible values for.</param>
         /// <returns>A sequence of values for the parameter.</returns>
-        internal static IEnumerable<object> GetValuesFor(ParameterInfo parameter)
+        public static IEnumerable<object> GetValuesFor(ParameterInfo parameter)
         {
             Requires.NotNull(parameter, nameof(parameter));
 
-            var valuesAttribute = parameter.GetCustomAttribute<CombinatorialValuesAttribute>();
-            if (valuesAttribute != null)
+            var providers = parameter.GetCustomAttributes().OfType<ICombinatorialValuesProvider>().ToArray();
+
+            if (providers.Any())
             {
-                return valuesAttribute.Values;
+                return providers.SelectMany(p => p.GetValues(parameter)).ToArray();
             }
 
             return GetValuesFor(parameter.ParameterType);
@@ -34,7 +36,7 @@ namespace Xunit
         /// </summary>
         /// <param name="dataType">The type to get possible values for.</param>
         /// <returns>A sequence of values for the <paramref name="dataType"/>.</returns>
-        internal static IEnumerable<object> GetValuesFor(Type dataType)
+        public static IEnumerable<object> GetValuesFor(Type dataType)
         {
             Requires.NotNull(dataType, nameof(dataType));
 

--- a/src/Xunit.Combinatorial/Xunit.Combinatorial.csproj
+++ b/src/Xunit.Combinatorial/Xunit.Combinatorial.csproj
@@ -47,7 +47,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CombinatorialDataAttribute.cs" />
+    <Compile Include="CombinatorialMemberData.cs" />
     <Compile Include="CombinatorialValuesAttribute.cs" />
+    <Compile Include="ICombinatorialValuesProvider.cs" />
     <Compile Include="PairwiseDataAttribute.cs" />
     <Compile Include="PairwiseStrategy.cs" />
     <Compile Include="PrivateErrorHelpers.cs" />


### PR DESCRIPTION
Implement this interface by CombinatorialValuesAttribute and add new Attribute CombinatorialMemberData which works similar to the XUnit MemberDataAttribute.

fixes https://github.com/AArnott/Xunit.Combinatorial/issues/1
closes https://github.com/AArnott/Xunit.Combinatorial/issues/6 (obsolete)

With this interface, I can implement support for F# Discriminated Unions (#6) in an external assembly.
