### PR TITLE
CombinatorialRangeAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,36 @@ combinatorial. In many cases the test reduction can be much greater.
 Notice that although the test cases are fewer, you can still find a test
 case that covers any *two* parameter values (thus *pair*wise).
 
+To run a test with a parameter over a range of values, we have
+`CombinatorialRangeAttribute` to generate tests over intervals of integers.
+```csharp
+[Theory, CombinatorialData]
+public void CombinatorialCustomRange([CombinatorialRange(0, 5)] int p1, [CombinatorialRange(0, 3, 2)] int p2)
+{
+    // Combinatorial generates these test cases:
+    // 0 0
+    // 1 0
+    // 2 0
+    // 3 0
+    // 4 0
+    // 0 2
+    // 1 2
+    // 2 2
+    // 3 2
+    // 4 2
+}
+```
+
+`CombinatorialRangeAttribute` has two distinct constructors.
+When supplied with two integers `from` and `count`, Xunit
+will create a test case where the parameter equals `from`, and
+it will increment the parameter by 1 for `count` number of cases.
+
+In the second constructor, `CombinatorialRangeAttribute` 
+accepts three integer parameters. In the generated cases, the
+parameter value will step up from the first integer to the
+second integer, and the third integer specifies the interval of
+which to increment.
+
+
  [NuPkg]: https://www.nuget.org/packages/Xunit.Combinatorial

--- a/src/Xunit.Combinatorial.Tests/CombinatorialRangeAttributeTests.cs
+++ b/src/Xunit.Combinatorial.Tests/CombinatorialRangeAttributeTests.cs
@@ -1,0 +1,46 @@
+namespace Xunit.Combinatorial.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class CombinatorialRangeAttributeTests
+    {
+        [Theory]
+        [InlineData(0, 5)]
+        public void CountOfIntegers_HappyPath_SetsAttributeWithRange(int from, int count)
+        {
+            object[] values = { 0, 1, 2, 3, 4 };
+            var attribute = new CombinatorialRangeAttribute(from, count);
+            Assert.Equal(values, attribute.Values);
+        }
+
+        [Theory]
+        [InlineData(0, -2)]
+        public void CountOfIntegers_NegativeCount_ArgOutOfRange(int from, int count)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CombinatorialRangeAttribute(from, count));
+        }
+
+        [Theory]
+        [InlineData(0, 7, 2, true)]
+        [InlineData(0, 8, 2, false)]
+        public void IntegerStep_HappyPath_SetsAttributeWithRange(int from, int to, int step, bool unevenInterval)
+        {
+            object[] expectedValues = unevenInterval ? new object[]{ 0, 2, 4, 6 } : new object[]{ 0, 2, 4, 6, 8 };
+
+            var attribute = new CombinatorialRangeAttribute(from, to, step);
+            Assert.Equal(expectedValues, attribute.Values);
+        }
+
+        [Theory]
+        [InlineData(4, 2, 1)]
+        [InlineData(1, 5, -1)]
+        public void IntegerStep_InvalidIntervalAndStep_ArgOutOfRange(int from, int to, int step)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CombinatorialRangeAttribute(from, to, step));
+        }
+    }
+}

--- a/src/Xunit.Combinatorial.Tests/SampleUses.cs
+++ b/src/Xunit.Combinatorial.Tests/SampleUses.cs
@@ -51,7 +51,7 @@
         }
 
         [Theory, CombinatorialData]
-        public void CombinatorialCustomRange([CustomCountRange] int p1, [CustomStepRange] int p2)
+        public void CombinatorialCustomRange([CombinatorialRange(0, 5)] int p1, [CombinatorialRange(0, 3, 2)] int p2)
         {
             // Combinatorial generates these test cases:
             // 0 0
@@ -73,24 +73,6 @@
         {
             public CustomValuesAttribute()
                 : base(new object[] { 5, 10, 15 })
-            {
-            }
-        }
-
-        [AttributeUsage(AttributeTargets.Parameter)]
-        private class CustomCountRangeAttribute : CombinatorialRangeAttribute
-        {
-            public CustomCountRangeAttribute()
-                : base(0, 5)
-            {
-            }
-        }
-
-        [AttributeUsage(AttributeTargets.Parameter)]
-        private class CustomStepRangeAttribute : CombinatorialRangeAttribute
-        {
-            public CustomStepRangeAttribute()
-                : base(0, 3, 2)
             {
             }
         }

--- a/src/Xunit.Combinatorial.Tests/SampleUses.cs
+++ b/src/Xunit.Combinatorial.Tests/SampleUses.cs
@@ -50,11 +50,45 @@
             // 15 15
         }
 
+        [Theory, CombinatorialData]
+        public void CombinatorialCustomRange([CustomCountRange] int p1, [CustomStepRange] int p2)
+        {
+            // Combinatorial generates these test cases:
+            // 0 0
+            // 1 0
+            // 2 0
+            // 3 0
+            // 4 0
+            // 0 2
+            // 1 2
+            // 2 2
+            // 3 2
+            // 4 2
+        }
+
         [AttributeUsage(AttributeTargets.Parameter)]
         private class CustomValuesAttribute : CombinatorialValuesAttribute
         {
             public CustomValuesAttribute()
                 : base(new object[] { 5, 10, 15 })
+            {
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Parameter)]
+        private class CustomCountRangeAttribute : CombinatorialRangeAttribute
+        {
+            public CustomCountRangeAttribute()
+                : base(0, 5)
+            {
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Parameter)]
+        private class CustomStepRangeAttribute : CombinatorialRangeAttribute
+        {
+            public CustomStepRangeAttribute()
+                : base(0, 3, 2)
             {
             }
         }

--- a/src/Xunit.Combinatorial.Tests/SampleUses.cs
+++ b/src/Xunit.Combinatorial.Tests/SampleUses.cs
@@ -64,6 +64,8 @@
             // 2 2
             // 3 2
             // 4 2
+            Assert.True(p1 == 0 || p1 == 1 || p1 == 2 || p1 == 3 || p1 == 4);
+            Assert.True(p2 == 0 || p2 == 2);
         }
 
         [AttributeUsage(AttributeTargets.Parameter)]

--- a/src/Xunit.Combinatorial/CombinatorialRangeAttribute.cs
+++ b/src/Xunit.Combinatorial/CombinatorialRangeAttribute.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved. Licensed under the Ms-PL.
+
+namespace Xunit
+{
+    using System;
+
+    /// <summary>
+    /// Specifies which range of values for this parameter should be used for running the test method.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class CombinatorialRangeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CombinatorialRangeAttribute"/> class.
+        /// </summary>
+        /// <param name="from">The value at the beginning of the range.</param>
+        /// <param name="count">The quantity of consecutive integer values to include.</param>
+        public CombinatorialRangeAttribute(int from, int count)
+        {
+            if (count < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            object[] values = new object[count];
+            for (int i = 0; i < count; i++)
+            {
+                values[i] = from + i;
+            }
+
+            this.Values = values;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CombinatorialRangeAttribute"/> class.
+        /// </summary>
+        /// <param name="from">The value at the beginning of the range.</param>
+        /// <param name="to">The value at the end of the range.</param>
+        /// <param name="step">The number of integers to step for each value in result.</param>
+        public CombinatorialRangeAttribute(int from, int to, int step)
+        {
+            // to cannot be less than from
+            if (to < from)
+            {
+                throw new ArgumentOutOfRangeException(nameof(to));
+            }
+
+            // step must be a positive integer
+            if (step < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(step));
+            }
+
+            int count = (to - from) / step;
+            object[] values = new object[count];
+            for (int i = 0; i < count; i += step)
+            {
+                values[i] = from + i;
+            }
+
+            this.Values = values;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CombinatorialRangeAttribute"/> class.
+        /// </summary>
+        /// <param name="from">The value at the beginning of the range.</param>
+        /// <param name="to">The value at the end of the range.</param>
+        /// <param name="step">The amount to skip for each value in result.</param>
+        public CombinatorialRangeAttribute(double from, double to, double step)
+        {
+            if (to < from)
+            {
+                throw new ArgumentOutOfRangeException(nameof(to));
+            }
+
+            if (step <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(step));
+            }
+
+            // Explicit cast truncates
+            int count = (int)((to - from) / step);
+            
+            object[] values = new object[count];
+            for (int i = 0; i < count; i++)
+            {
+                values[i] = from + (i * step);
+            }
+
+            this.Values = values;
+        }
+
+        /// <summary>
+        /// Gets the values that should be passed to this parameter on the test method.
+        /// </summary>
+        /// <value>An array of values.</value>
+        public object[] Values { get; }
+    }
+}

--- a/src/Xunit.Combinatorial/CombinatorialRangeAttribute.cs
+++ b/src/Xunit.Combinatorial/CombinatorialRangeAttribute.cs
@@ -14,7 +14,10 @@ namespace Xunit
         /// Initializes a new instance of the <see cref="CombinatorialRangeAttribute"/> class.
         /// </summary>
         /// <param name="from">The value at the beginning of the range.</param>
-        /// <param name="count">The quantity of consecutive integer values to include.</param>
+        /// <param name="count">
+        /// The quantity of consecutive integer values to include.
+        /// Cannot be less than 1, which would conceptually result in zero test cases.
+        /// </param>
         public CombinatorialRangeAttribute(int from, int count)
         {
             if (count < 1)
@@ -35,17 +38,23 @@ namespace Xunit
         /// Initializes a new instance of the <see cref="CombinatorialRangeAttribute"/> class.
         /// </summary>
         /// <param name="from">The value at the beginning of the range.</param>
-        /// <param name="to">The value at the end of the range.</param>
-        /// <param name="step">The number of integers to step for each value in result.</param>
+        /// <param name="to">
+        /// The value at the end of the range.
+        /// Cannot be less than "from" parameter.
+        /// When "to" and "from" are equal, CombinatorialValues is more appropriate.
+        /// </param>
+        /// <param name="step">
+        /// The number of integers to step for each value in result.
+        /// Cannot be less than one. Stepping zero or backwards is not useful.
+        /// Stepping over "to" does not add another value to the range.
+        /// </param>
         public CombinatorialRangeAttribute(int from, int to, int step)
         {
-            // to cannot be less than from
-            if (to < from)
+            if (to <= from)
             {
                 throw new ArgumentOutOfRangeException(nameof(to));
             }
 
-            // step must be a positive integer
             if (step < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(step));

--- a/src/Xunit.Combinatorial/CombinatorialRangeAttribute.cs
+++ b/src/Xunit.Combinatorial/CombinatorialRangeAttribute.cs
@@ -51,37 +51,7 @@ namespace Xunit
                 throw new ArgumentOutOfRangeException(nameof(step));
             }
 
-            int count = (to - from) / step;
-            object[] values = new object[count];
-            for (int i = 0; i < count; i += step)
-            {
-                values[i] = from + i;
-            }
-
-            this.Values = values;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CombinatorialRangeAttribute"/> class.
-        /// </summary>
-        /// <param name="from">The value at the beginning of the range.</param>
-        /// <param name="to">The value at the end of the range.</param>
-        /// <param name="step">The amount to skip for each value in result.</param>
-        public CombinatorialRangeAttribute(double from, double to, double step)
-        {
-            if (to < from)
-            {
-                throw new ArgumentOutOfRangeException(nameof(to));
-            }
-
-            if (step <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(step));
-            }
-
-            // Explicit cast truncates
-            int count = (int)((to - from) / step);
-            
+            int count = ((to - from) / step) + 1;
             object[] values = new object[count];
             for (int i = 0; i < count; i++)
             {

--- a/src/Xunit.Combinatorial/ValuesUtilities.cs
+++ b/src/Xunit.Combinatorial/ValuesUtilities.cs
@@ -21,6 +21,13 @@ namespace Xunit
             Requires.NotNull(parameter, nameof(parameter));
 
             var valuesAttribute = parameter.GetCustomAttribute<CombinatorialValuesAttribute>();
+            var rangeAttribute = parameter.GetCustomAttribute<CombinatorialRangeAttribute>();
+
+            if (rangeAttribute != null)
+            {
+                return rangeAttribute.Values;
+            }
+
             if (valuesAttribute != null)
             {
                 return valuesAttribute.Values;

--- a/src/Xunit.Combinatorial/ValuesUtilities.cs
+++ b/src/Xunit.Combinatorial/ValuesUtilities.cs
@@ -21,16 +21,15 @@ namespace Xunit
             Requires.NotNull(parameter, nameof(parameter));
 
             var valuesAttribute = parameter.GetCustomAttribute<CombinatorialValuesAttribute>();
-            var rangeAttribute = parameter.GetCustomAttribute<CombinatorialRangeAttribute>();
-
-            if (rangeAttribute != null)
-            {
-                return rangeAttribute.Values;
-            }
-
             if (valuesAttribute != null)
             {
                 return valuesAttribute.Values;
+            }
+
+            var rangeAttribute = parameter.GetCustomAttribute<CombinatorialRangeAttribute>();
+            if (rangeAttribute != null)
+            {
+                return rangeAttribute.Values;
             }
 
             return GetValuesFor(parameter.ParameterType);


### PR DESCRIPTION
This is concerning Isssue #18 

This new CombinatorialRangeAttribute can be used to test with a range of integers. The attribute will count up from a number if given two integers, or count by "x" from a starting value to an ending value if given three integers. My aim is to satisfy some of the functionality of Nunit's [Range] attribute, as CombinatorialValuesAttribute already covers Nunit's [Values] attribute and I sometimes need to convert projects from Nunit to Xunit in my work.

This is my first attempt at an open-source contribution, please let me know if I've missed anything.