### PR TITLE
Add Nullable<> support to CombinatorialData/PairwiseData

### DIFF
--- a/src/Xunit.Combinatorial.Tests/CombinatorialDataAttributeTests.cs
+++ b/src/Xunit.Combinatorial.Tests/CombinatorialDataAttributeTests.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
-    using System.Text;
     using Sdk;
     using Validation;
 
@@ -46,6 +45,17 @@
         {
             AssertData(new object[][]
             {
+                new object[] { 0 },
+                new object[] { 1 },
+            });
+        }
+
+        [Fact]
+        public void GetData_NullableInt()
+        {
+            AssertData(new object[][]
+            {
+                new object[] { null },
                 new object[] { 0 },
                 new object[] { 1 },
             });
@@ -93,7 +103,26 @@
         }
 
         [Fact]
+        public void GetData_NullableDateTimeKind()
+        {
+            AssertData(new object[][]
+            {
+                new object[] { null },
+                new object[] { DateTimeKind.Unspecified },
+                new object[] { DateTimeKind.Utc },
+                new object[] { DateTimeKind.Local },
+            });
+        }
+
+        [Fact]
         public void GetData_UnsupportedType()
+        {
+            Assert.Throws<NotSupportedException>(() => GetData(new CombinatorialDataAttribute()));
+            Assert.Throws<NotSupportedException>(() => GetData(new PairwiseDataAttribute()));
+        }
+
+        [Fact]
+        public void GetData_UnsupportedNullableType()
         {
             Assert.Throws<NotSupportedException>(() => GetData(new CombinatorialDataAttribute()));
             Assert.Throws<NotSupportedException>(() => GetData(new PairwiseDataAttribute()));
@@ -120,10 +149,13 @@
         private static void Suppose_Bool(bool p1) { }
         private static void Suppose_BoolBool(bool p1, bool p2) { }
         private static void Suppose_Int(int p1) { }
+        private static void Suppose_NullableInt(int? p1) { }
         private static void Suppose_Int_35([CombinatorialValues(3, 5)] int p1) { }
         private static void Suppose_string_int_bool_Values([CombinatorialValues("a", "b")]string p1, [CombinatorialValues(2, 4, 6)]int p2, bool p3) { }
         private static void Suppose_DateTimeKind(DateTimeKind p1) { }
+        private static void Suppose_NullableDateTimeKind(DateTimeKind? p1) { }
         private static void Suppose_UnsupportedType(System.AggregateException p1) { }
+        private static void Suppose_UnsupportedNullableType(Guid? p1) { }
 
         private static void AssertData(IEnumerable<object[]> expectedCombinatorial, [CallerMemberName] string testMethodName = null)
         {

--- a/src/Xunit.Combinatorial/ValuesUtilities.cs
+++ b/src/Xunit.Combinatorial/ValuesUtilities.cs
@@ -61,10 +61,52 @@ namespace Xunit
                     yield return Enum.Parse(dataType, name);
                 }
             }
+            else if (IsNullable(dataType, out Type innerDataType))
+            {
+                yield return null;
+                foreach (object value in GetValuesFor(innerDataType))
+                {
+                    yield return value;
+                }
+            }
             else
             {
                 throw new NotSupportedException();
             }
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="dataType"/> is <see cref="Nullable{T}"/>
+        /// and extracts the inner type, if any.
+        /// </summary>
+        /// <param name="dataType">
+        /// The type to test whether it is <see cref="Nullable{T}"/>
+        /// </param>
+        /// <param name="innerDataType">
+        /// When this method returns, contains the inner type of the Nullable, if the
+        /// type is Nullable is found; otherwise, null.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the type is a Nullable type; otherwise <see langword="false"/>.
+        /// </returns>
+        private static bool IsNullable(Type dataType, out Type innerDataType)
+        {
+            innerDataType = null;
+
+            var ti = dataType.GetTypeInfo();
+
+            if (!ti.IsGenericType)
+            {
+                return false;
+            }
+
+            if (ti.GetGenericTypeDefinition() != typeof(Nullable<>))
+            {
+                return false;
+            }
+
+            innerDataType = ti.GenericTypeArguments[0];
+            return true;
         }
     }
 }


### PR DESCRIPTION
The `[CombinatorialData]` and `[PairwiseData]` attributes now works on
`Nullable<T>` wrappers around the underlying types is already supports.
The values tested for `Nullable<T>` are the union of

* null and
* the values tested for bare T.

Fixes https://github.com/AArnott/Xunit.Combinatorial/issues/23