### PR TITLE
Retarget to net462

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Validation" Version="2.5.51" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="xunit" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Xunit.Combinatorial/Xunit.Combinatorial.csproj
+++ b/src/Xunit.Combinatorial/Xunit.Combinatorial.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <RootNamespace>Xunit</RootNamespace>
 
     <Title>Combinatorial testing with Xunit</Title>

--- a/test/Xunit.Combinatorial.Tests/Xunit.Combinatorial.Tests.csproj
+++ b/test/Xunit.Combinatorial.Tests/Xunit.Combinatorial.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Xunit.Combinatorial\Xunit.Combinatorial.csproj" />


### PR DESCRIPTION
.NET Framework 4.6.2 is the oldest .NET Framework that Microsoft still supports.