### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.12.6",
+      "version": "17.13.1",
       "commands": [
         "dotnet-coverage"
       ],
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "docfx": {
-      "version": "2.78.1",
+      "version": "2.78.2",
       "commands": [
         "docfx"
       ],

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites
 

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -6,4 +6,4 @@ _layout: landing
 
 This is your docfx landing page.
 
-Click "Docs" across the top to get get started.
+Click "Docs" across the top to get started.


### PR DESCRIPTION
- **Add docfx verification to build**
- **Fix nb.gv failure during docfx build**
- **Remove double word from boilerplate docfx text**
- **Bump docfx to 2.78.2**
- **Bump dotnet-coverage to 17.13.1**
