### PR TITLE
Update `ValuesUtilities.GetValuesFor` to support all primitives

### DIFF
--- a/src/Xunit.Combinatorial/ValuesUtilities.cs
+++ b/src/Xunit.Combinatorial/ValuesUtilities.cs
@@ -38,21 +38,18 @@ internal static class ValuesUtilities
     {
         Requires.NotNull(dataType, nameof(dataType));
 
-        if (dataType == typeof(bool))
-        {
-            yield return true;
-            yield return false;
-        }
-        else if (dataType == typeof(int))
-        {
-            yield return 0;
-            yield return 1;
-        }
-        else if (dataType.GetTypeInfo().IsEnum)
+        if (dataType.GetTypeInfo().IsEnum)
         {
             foreach (string name in Enum.GetNames(dataType))
             {
                 yield return Enum.Parse(dataType, name);
+            }
+        }
+        else if (dataType.IsPrimitive)
+        {
+            foreach (var i in new[] { 0, 1 })
+            {
+                yield return Convert.ChangeType(i, dataType);
             }
         }
         else if (IsNullable(dataType, out Type? innerDataType))


### PR DESCRIPTION
This PR addresses the issue described in #155. Rather than checking for specific types, a more generalized solution was achieved by checking `Type.IsPrimitive` and then using `Convert.ChangeType` to return `0` and `1`. This works with not only `bool` and `int`, but all primitives, such as `sbyte` and `double`.