### PR TITLE
deps: block Renovate updates to xunit.v3.extensibility.core

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,12 @@
 	"labels": ["dependencies"],
 	"packageRules": [
 		{
+			"matchManagers": ["nuget"],
+			"matchFileNames": ["src/Xunit.Combinatorial/Xunit.Combinatorial.csproj"],
+			"matchPackageNames": ["xunit.v3.extensibility.core"],
+			"enabled": false
+		},
+		{
 			"matchPackageNames": ["nbgv", "nerdbank.gitversioning"],
 			"groupName": "nbgv and nerdbank.gitversioning updates"
 		},


### PR DESCRIPTION
## Summary
- disable Renovate updates for `xunit.v3.extensibility.core` when the dependency is in `src/Xunit.Combinatorial/Xunit.Combinatorial.csproj`
- keep other Renovate-managed xUnit dependency updates unchanged

## Why
PR #153 updated `xunit.v3.extensibility.core` in `src/Xunit.Combinatorial/Xunit.Combinatorial.csproj`, but that package version should stay pinned there. This rule prevents Renovate from opening that same kind of PR again while leaving other dependency updates enabled.