### PR TITLE
Allow vetoing generated combinatorial and pairwise test cases

### DIFF
--- a/src/Xunit.Combinatorial/AnyDataValue.cs
+++ b/src/Xunit.Combinatorial/AnyDataValue.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+namespace Xunit;
+
+/// <summary>
+/// A sentinel type that matches any value in the same test method parameter position.
+/// </summary>
+/// <remarks>
+/// Use this with <see langword="typeof"/> when specifying exclusions, for example:
+/// <c>[ExcludeTestCase(typeof(AnyDataValue), false)]</c>.
+/// </remarks>
+public static class AnyDataValue
+{
+}

--- a/src/Xunit.Combinatorial/CombinatorialDataAttribute.cs
+++ b/src/Xunit.Combinatorial/CombinatorialDataAttribute.cs
@@ -38,8 +38,9 @@ public class CombinatorialDataAttribute : DataAttribute
             values[i] = ValuesUtilities.GetValuesFor(parameters[i]).ToList();
         }
 
+        ExcludeTestCaseAttribute[] exclusions = ExcludeTestCaseAttribute.GetExclusions(testMethod);
         object[]? currentValues = new object[parameters.Length];
-        return this.FillCombinations(parameters, values, currentValues, 0);
+        return this.FillCombinations(parameters, values, currentValues, exclusions, 0);
     }
 
     /// <summary>
@@ -49,13 +50,15 @@ public class CombinatorialDataAttribute : DataAttribute
     /// <param name="parameters">The parameters taken by the test method.</param>
     /// <param name="candidateValues">An array of each argument's list of possible values.</param>
     /// <param name="currentValues">An array that is being recursively initialized with a set of arguments to pass to the test method.</param>
+    /// <param name="exclusions">Test cases that should not be generated.</param>
     /// <param name="index">The index into <paramref name="currentValues"/> that this particular invocation should rotate through <paramref name="candidateValues"/> for.</param>
     /// <returns>A sequence of all combinations of arguments from <paramref name="candidateValues"/>, starting at <paramref name="index"/>.</returns>
-    private IEnumerable<object?[]> FillCombinations(ParameterInfo[] parameters, List<object?>[] candidateValues, object?[] currentValues, int index)
+    private IEnumerable<object?[]> FillCombinations(ParameterInfo[] parameters, List<object?>[] candidateValues, object?[] currentValues, ExcludeTestCaseAttribute[] exclusions, int index)
     {
         Requires.NotNull(parameters, nameof(parameters));
         Requires.NotNull(candidateValues, nameof(candidateValues));
         Requires.NotNull(currentValues, nameof(currentValues));
+        Requires.NotNull(exclusions, nameof(exclusions));
         Requires.Argument(parameters.Length == candidateValues.Length, nameof(candidateValues), $"Expected to have same array length as {nameof(parameters)}");
         Requires.Argument(parameters.Length == currentValues.Length, nameof(currentValues), $"Expected to have same array length as {nameof(parameters)}");
         Requires.Range(index >= 0 && index < parameters.Length, nameof(index));
@@ -66,7 +69,7 @@ public class CombinatorialDataAttribute : DataAttribute
 
             if (index + 1 < parameters.Length)
             {
-                foreach (object?[] result in this.FillCombinations(parameters, candidateValues, currentValues, index + 1))
+                foreach (object?[] result in this.FillCombinations(parameters, candidateValues, currentValues, exclusions, index + 1))
                 {
                     yield return result;
                 }
@@ -77,7 +80,10 @@ public class CombinatorialDataAttribute : DataAttribute
                 // Copy the array before returning since we're about to mutate currentValues
                 object[] finalSet = new object[currentValues.Length];
                 Array.Copy(currentValues, finalSet, currentValues.Length);
-                yield return finalSet;
+                if (!exclusions.Any(e => e.Matches(finalSet)))
+                {
+                    yield return finalSet;
+                }
             }
         }
     }

--- a/src/Xunit.Combinatorial/ExcludeTestCaseAttribute.cs
+++ b/src/Xunit.Combinatorial/ExcludeTestCaseAttribute.cs
@@ -1,0 +1,183 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+namespace Xunit;
+
+/// <summary>
+/// Suppresses generation of a specific test case from a combinatorial or pairwise theory.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+public class ExcludeTestCaseAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExcludeTestCaseAttribute"/> class.
+    /// </summary>
+    /// <param name="arguments">The values that match the test case to exclude.</param>
+    public ExcludeTestCaseAttribute(params object?[] arguments)
+    {
+        this.Arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+    }
+
+    /// <summary>
+    /// Gets the values that match the test case to exclude.
+    /// </summary>
+    public object?[] Arguments { get; }
+
+    /// <summary>
+    /// Gets and validates the test case exclusions on a test method.
+    /// </summary>
+    /// <param name="testMethod">The test method to inspect for exclusions.</param>
+    /// <returns>The exclusions applied to <paramref name="testMethod"/>.</returns>
+    internal static ExcludeTestCaseAttribute[] GetExclusions(MethodInfo testMethod)
+    {
+        Requires.NotNull(testMethod, nameof(testMethod));
+
+        int parameterCount = testMethod.GetParameters().Length;
+        ExcludeTestCaseAttribute[] exclusions = testMethod.GetCustomAttributes<ExcludeTestCaseAttribute>(true).ToArray();
+        foreach (ExcludeTestCaseAttribute exclusion in exclusions)
+        {
+            if (exclusion.Arguments.Length != parameterCount)
+            {
+                throw new ArgumentException($"The number of arguments in {nameof(ExcludeTestCaseAttribute)} must match the number of test method parameters.", nameof(testMethod));
+            }
+        }
+
+        return exclusions;
+    }
+
+    /// <summary>
+    /// Creates a predicate that checks whether an indexed test case is allowed.
+    /// </summary>
+    /// <param name="candidateValues">The possible values for each parameter position.</param>
+    /// <param name="exclusions">The exclusions to evaluate against indexed test cases.</param>
+    /// <returns>A predicate that returns <see langword="true"/> when a test case is allowed.</returns>
+    internal static Predicate<int[]>? CreateIndexMatcher(List<object?>[] candidateValues, ExcludeTestCaseAttribute[] exclusions)
+    {
+        Requires.NotNull(candidateValues, nameof(candidateValues));
+        Requires.NotNull(exclusions, nameof(exclusions));
+
+        if (exclusions.Length == 0)
+        {
+            return null;
+        }
+
+        List<IndexedExclusion> indexedExclusions = [];
+        foreach (ExcludeTestCaseAttribute exclusion in exclusions)
+        {
+            IndexedExclusion? indexedExclusion = IndexedExclusion.Create(candidateValues, exclusion);
+            if (indexedExclusion is not null)
+            {
+                indexedExclusions.Add(indexedExclusion);
+            }
+        }
+
+        if (indexedExclusions.Count == 0)
+        {
+            return null;
+        }
+
+        return testCase =>
+        {
+            Requires.NotNull(testCase, nameof(testCase));
+
+            foreach (IndexedExclusion exclusion in indexedExclusions)
+            {
+                if (exclusion.Matches(testCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether this attribute matches a test case.
+    /// </summary>
+    /// <param name="testCase">The test case to compare against this exclusion.</param>
+    /// <returns>A value indicating whether this attribute matches <paramref name="testCase"/>.</returns>
+    internal bool Matches(object?[] testCase)
+    {
+        Requires.NotNull(testCase, nameof(testCase));
+        Requires.Argument(this.Arguments.Length == testCase.Length, nameof(testCase), $"Expected to have same array length as {nameof(this.Arguments)}");
+
+        for (int i = 0; i < this.Arguments.Length; i++)
+        {
+            if (!IsAny(this.Arguments[i]) && !EqualityComparer<object?>.Default.Equals(this.Arguments[i], testCase[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsAny(object? argument) => argument is Type type && type == typeof(AnyDataValue);
+
+    private sealed class IndexedExclusion
+    {
+        private readonly bool[]?[] matchingValueIndices;
+
+        private IndexedExclusion(bool[]?[] matchingValueIndices)
+        {
+            this.matchingValueIndices = matchingValueIndices;
+        }
+
+        internal static IndexedExclusion? Create(List<object?>[] candidateValues, ExcludeTestCaseAttribute exclusion)
+        {
+            Requires.NotNull(candidateValues, nameof(candidateValues));
+            Requires.NotNull(exclusion, nameof(exclusion));
+            Requires.Argument(candidateValues.Length == exclusion.Arguments.Length, nameof(candidateValues), $"Expected to have same array length as {nameof(exclusion.Arguments)}");
+
+            bool[]?[] matchingValueIndices = new bool[]?[candidateValues.Length];
+            for (int parameterIndex = 0; parameterIndex < candidateValues.Length; parameterIndex++)
+            {
+                object? excludedValue = exclusion.Arguments[parameterIndex];
+                if (IsAny(excludedValue))
+                {
+                    continue;
+                }
+
+                bool[] matches = new bool[candidateValues[parameterIndex].Count];
+                bool anyMatches = false;
+                for (int valueIndex = 0; valueIndex < candidateValues[parameterIndex].Count; valueIndex++)
+                {
+                    if (EqualityComparer<object?>.Default.Equals(candidateValues[parameterIndex][valueIndex], excludedValue))
+                    {
+                        matches[valueIndex] = true;
+                        anyMatches = true;
+                    }
+                }
+
+                if (!anyMatches)
+                {
+                    return null;
+                }
+
+                matchingValueIndices[parameterIndex] = matches;
+            }
+
+            return new IndexedExclusion(matchingValueIndices);
+        }
+
+        internal bool Matches(int[] testCase)
+        {
+            Requires.NotNull(testCase, nameof(testCase));
+            Requires.Argument(this.matchingValueIndices.Length == testCase.Length, nameof(testCase), $"Expected to have same array length as {nameof(this.matchingValueIndices)}");
+
+            for (int parameterIndex = 0; parameterIndex < testCase.Length; parameterIndex++)
+            {
+                bool[]? matches = this.matchingValueIndices[parameterIndex];
+                if (matches is not null && !matches[testCase[parameterIndex]])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Xunit.Combinatorial/PairwiseDataAttribute.cs
+++ b/src/Xunit.Combinatorial/PairwiseDataAttribute.cs
@@ -30,7 +30,9 @@ public class PairwiseDataAttribute : DataAttribute
             values[i] = ValuesUtilities.GetValuesFor(parameters[i]).ToList();
         }
 
-        List<int[]>? testCaseInfo = PairwiseStrategy.GetTestCases(values.Select(v => v.Count).ToArray());
+        ExcludeTestCaseAttribute[] exclusions = ExcludeTestCaseAttribute.GetExclusions(testMethod);
+        Predicate<int[]>? isTestCaseAllowed = ExcludeTestCaseAttribute.CreateIndexMatcher(values, exclusions);
+        List<int[]> testCaseInfo = PairwiseStrategy.GetTestCases(values.Select(v => v.Count).ToArray(), isTestCaseAllowed);
         return from testCase in testCaseInfo
                select testCase.Select((j, i) => values[i][j]).ToArray();
     }

--- a/src/Xunit.Combinatorial/PairwiseStrategy.cs
+++ b/src/Xunit.Combinatorial/PairwiseStrategy.cs
@@ -65,7 +65,23 @@ internal static class PairwiseStrategy
     /// </returns>
     public static List<int[]> GetTestCases(int[] dimensions)
     {
-        return (from testCase in new PairwiseTestCaseGenerator().GetTestCases(dimensions)
+        return GetTestCases(dimensions, null);
+    }
+
+    /// <summary>
+    /// Creates a set of test cases for specified dimensions.
+    /// </summary>
+    /// <param name="dimensions">
+    /// An array which contains information about dimensions. Each element of
+    /// this array represents a number of features in the specific dimension.
+    /// </param>
+    /// <param name="isTestCaseAllowed">A predicate that returns <see langword="true"/> when a generated test case is allowed.</param>
+    /// <returns>
+    /// A set of test cases.
+    /// </returns>
+    public static List<int[]> GetTestCases(int[] dimensions, Predicate<int[]>? isTestCaseAllowed)
+    {
+        return (from testCase in new PairwiseTestCaseGenerator().GetTestCases(dimensions, isTestCaseAllowed)
                 select testCase.Features).ToList();
     }
 
@@ -323,19 +339,26 @@ internal static class PairwiseStrategy
         private List<FeatureTuple>[][]? uncoveredTuples;
 
         /// <summary>
+        /// A predicate that determines whether a generated test case satisfies caller-supplied constraints.
+        /// </summary>
+        private Predicate<int[]>? isTestCaseAllowed;
+
+        /// <summary>
         /// Creates a set of test cases for specified dimensions.
         /// </summary>
         /// <param name="dimensions">
         /// An array which contains information about dimensions. Each element of
         /// this array represents a number of features in the specific dimension.
         /// </param>
+        /// <param name="isTestCaseAllowed">A predicate that returns <see langword="true"/> when a generated test case is allowed.</param>
         /// <returns>
         /// A set of test cases.
         /// </returns>
-        public List<TestCaseInfo> GetTestCases(int[] dimensions)
+        public List<TestCaseInfo> GetTestCases(int[] dimensions, Predicate<int[]>? isTestCaseAllowed)
         {
             this.prng = new FleaRand(15485863);
             this.dimensions = dimensions;
+            this.isTestCaseAllowed = isTestCaseAllowed;
 
             this.CreateAllTuples();
 
@@ -351,6 +374,13 @@ internal static class PairwiseStrategy
                 }
 
                 TestCaseInfo? testCase = this.CreateTestCase(tuple);
+
+                if (testCase is null)
+                {
+                    // No allowed row can cover this tuple, so remove it to avoid repeatedly trying to satisfy an impossible constraint.
+                    this.RemoveTuple(tuple);
+                    continue;
+                }
 
                 this.RemoveTuplesCoveredByTest(testCase);
 
@@ -420,14 +450,18 @@ internal static class PairwiseStrategy
             return null;
         }
 
-        private TestCaseInfo CreateTestCase(FeatureTuple tuple)
+        private TestCaseInfo? CreateTestCase(FeatureTuple tuple)
         {
             TestCaseInfo? bestTestCase = null;
             int bestCoverage = -1;
 
             for (int i = 0; i < 7; i++)
             {
-                TestCaseInfo testCase = this.CreateRandomTestCase(tuple);
+                TestCaseInfo? testCase = this.CreateRandomTestCase(tuple);
+                if (testCase is null)
+                {
+                    continue;
+                }
 
                 int coverage = this.MaximizeCoverage(testCase, tuple);
 
@@ -438,10 +472,10 @@ internal static class PairwiseStrategy
                 }
             }
 
-            return bestTestCase!;
+            return bestTestCase;
         }
 
-        private TestCaseInfo CreateRandomTestCase(FeatureTuple tuple)
+        private TestCaseInfo? CreateRandomTestCase(FeatureTuple tuple)
         {
             TestCaseInfo result = new TestCaseInfo(this.dimensions!.Length);
 
@@ -455,7 +489,7 @@ internal static class PairwiseStrategy
                 result.Features[tuple[i].Dimension] = tuple[i].Feature;
             }
 
-            return result;
+            return this.IsTestCaseAllowed(result) ? result : this.FindAllowedTestCase(tuple);
         }
 
         private int MaximizeCoverage(TestCaseInfo testCase, FeatureTuple tuple)
@@ -534,6 +568,11 @@ internal static class PairwiseStrategy
             {
                 testCase.Features[dimension] = f;
 
+                if (!this.IsTestCaseAllowed(testCase))
+                {
+                    continue;
+                }
+
                 int coverage = this.CountTuplesCoveredByTest(testCase, dimension, f);
 
                 if (coverage >= bestCoverage)
@@ -551,6 +590,66 @@ internal static class PairwiseStrategy
             testCase.Features[dimension] = bestFeatures[this.GetNextRandomNumber() % bestFeatures.Count];
 
             return bestCoverage;
+        }
+
+        /// <summary>
+        /// Exhaustively searches the feature space to find any allowed test case that covers a tuple when a random test case is vetoed.
+        /// </summary>
+        /// <param name="tuple">The tuple that must be covered by the returned test case.</param>
+        /// <returns>An allowed test case, or <see langword="null"/> when none can cover <paramref name="tuple"/>.</returns>
+        private TestCaseInfo? FindAllowedTestCase(FeatureTuple tuple)
+        {
+            TestCaseInfo result = new TestCaseInfo(this.dimensions!.Length);
+            bool[] initializedDimensions = new bool[this.dimensions.Length];
+
+            for (int i = 0; i < tuple.Length; i++)
+            {
+                result.Features[tuple[i].Dimension] = tuple[i].Feature;
+                initializedDimensions[tuple[i].Dimension] = true;
+            }
+
+            return this.FindAllowedTestCase(result, initializedDimensions, 0) ? result : null;
+        }
+
+        /// <summary>
+        /// Recursively assigns features to uninitialized dimensions until it finds an allowed test case.
+        /// </summary>
+        /// <param name="testCase">The test case being initialized.</param>
+        /// <param name="initializedDimensions">A value indicating whether each dimension has already been assigned.</param>
+        /// <param name="dimension">The dimension to initialize.</param>
+        /// <returns>A value indicating whether <paramref name="testCase"/> was assigned allowed features.</returns>
+        private bool FindAllowedTestCase(TestCaseInfo testCase, bool[] initializedDimensions, int dimension)
+        {
+            if (dimension == this.dimensions!.Length)
+            {
+                return this.IsTestCaseAllowed(testCase);
+            }
+
+            if (initializedDimensions[dimension])
+            {
+                return this.FindAllowedTestCase(testCase, initializedDimensions, dimension + 1);
+            }
+
+            for (int f = 0; f < this.dimensions[dimension]; f++)
+            {
+                testCase.Features[dimension] = f;
+                if (this.FindAllowedTestCase(testCase, initializedDimensions, dimension + 1))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether a test case satisfies the caller-supplied constraints.
+        /// </summary>
+        /// <param name="testCase">The test case to validate.</param>
+        /// <returns><see langword="true"/> if the test case is allowed; otherwise, <see langword="false"/>.</returns>
+        private bool IsTestCaseAllowed(TestCaseInfo testCase)
+        {
+            return this.isTestCaseAllowed?.Invoke(testCase.Features) ?? true;
         }
 
         private int CountTuplesCoveredByTest(TestCaseInfo testCase, int dimension, int feature)
@@ -586,6 +685,18 @@ internal static class PairwiseStrategy
                         }
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Removes a tuple that cannot be covered by any allowed test case.
+        /// </summary>
+        /// <param name="tuple">The tuple to remove.</param>
+        private void RemoveTuple(FeatureTuple tuple)
+        {
+            for (int i = 0; i < tuple.Length; i++)
+            {
+                this.uncoveredTuples![tuple[i].Dimension][tuple[i].Feature].Remove(tuple);
             }
         }
     }

--- a/test/Xunit.Combinatorial.Tests/CombinatorialDataAttributeTests.cs
+++ b/test/Xunit.Combinatorial.Tests/CombinatorialDataAttributeTests.cs
@@ -38,6 +38,61 @@ public class CombinatorialDataAttributeTests
     }
 
     [Fact]
+    public void GetData_BoolBool_ExcludeTrueFalse()
+    {
+        AssertData(
+        [
+            [true, true],
+            [false, true],
+            [false, false],
+        ]);
+    }
+
+    [Fact]
+    public void GetData_Pairwise_ExcludeTrueFalse()
+    {
+        IEnumerable<object[]> actualPairwise = GetData(new PairwiseDataAttribute(), nameof(this.GetData_BoolBool_ExcludeTrueFalse));
+        object?[] excludedTestCase = [true, false];
+
+        Assert.DoesNotContain(actualPairwise, row => excludedTestCase.SequenceEqual(row));
+    }
+
+    [Fact]
+    public void GetData_BoolBool_ExcludeFirstParameterTrue()
+    {
+        AssertData(
+        [
+            [false, true],
+            [false, false],
+        ]);
+    }
+
+    [Fact]
+    public void GetData_BoolBool_ExcludeAnyFalse()
+    {
+        AssertData(
+        [
+            [true, true],
+            [false, true],
+        ]);
+    }
+
+    [Fact]
+    public void GetData_BoolBoolBool_ExcludeTrueTrueTrue()
+    {
+        AssertData(
+        [
+            [true, true, false],
+            [true, false, true],
+            [true, false, false],
+            [false, true, true],
+            [false, true, false],
+            [false, false, true],
+            [false, false, false],
+        ]);
+    }
+
+    [Fact]
     public void GetData_Int()
     {
         AssertData(
@@ -152,6 +207,26 @@ public class CombinatorialDataAttributeTests
     {
     }
 
+    [ExcludeTestCase(true, false)]
+    private static void Suppose_BoolBool_ExcludeTrueFalse(bool p1, bool p2)
+    {
+    }
+
+    [ExcludeFirstParameterTrue]
+    private static void Suppose_BoolBool_ExcludeFirstParameterTrue(bool p1, bool p2)
+    {
+    }
+
+    [ExcludeTestCase(typeof(AnyDataValue), false)]
+    private static void Suppose_BoolBool_ExcludeAnyFalse(bool p1, bool p2)
+    {
+    }
+
+    [ExcludeTestCase(true, true, true)]
+    private static void Suppose_BoolBoolBool_ExcludeTrueTrueTrue(bool p1, bool p2, bool p3)
+    {
+    }
+
     private static void Suppose_Int(int p1)
     {
     }
@@ -195,51 +270,45 @@ public class CombinatorialDataAttributeTests
 
         // Verify that the combinatorial result is as expected.
         Assert.Equal(expectedCombinatorial, actualCombinatorial);
+        Assert.All(
+            actualPairwise,
+            row => Assert.Contains(
+                expectedCombinatorial,
+                expected => expected.SequenceEqual(row)));
 
         if (expectedCombinatorial.Any())
         {
             // Verify that the pairwise result covers every pair.
-            HashSet<object?>[] possibleValues = ExtractPossibleValues(expectedCombinatorial);
-
-            for (int i = 0; i < possibleValues.Length - 1; i++)
+            int parameterCount = expectedCombinatorial.First().Length;
+            for (int i = 0; i < parameterCount - 1; i++)
             {
-                for (int j = i + 1; j < possibleValues.Length; j++)
+                for (int j = i + 1; j < parameterCount; j++)
                 {
-                    foreach (object? iValue in possibleValues[i])
+                    foreach ((object? first, object? second) in ExtractPossiblePairs(expectedCombinatorial, i, j))
                     {
-                        foreach (object? jValue in possibleValues[j])
-                        {
-                            Assert.Contains(
-                                actualPairwise,
-                                testCase =>
-                                    EqualityComparer<object?>.Default.Equals(testCase[i], iValue) &&
-                                    EqualityComparer<object?>.Default.Equals(testCase[j], jValue));
-                        }
+                        Assert.Contains(
+                            actualPairwise,
+                            testCase =>
+                                EqualityComparer<object?>.Default.Equals(testCase[i], first) &&
+                                EqualityComparer<object?>.Default.Equals(testCase[j], second));
                     }
                 }
             }
         }
     }
 
-    private static HashSet<object?>[] ExtractPossibleValues(IEnumerable<object?[]> combinatorialTestCases)
+    private static HashSet<(object? First, object? Second)> ExtractPossiblePairs(IEnumerable<object?[]> combinatorialTestCases, int firstParameterIndex, int secondParameterIndex)
     {
         Requires.NotNull(combinatorialTestCases, nameof(combinatorialTestCases));
 
-        HashSet<object?>[] possibleValues = new HashSet<object?>[combinatorialTestCases.First().Length];
-        for (int i = 0; i < possibleValues.Length; i++)
-        {
-            possibleValues[i] = new HashSet<object?>();
-        }
+        HashSet<(object? First, object? Second)> possiblePairs = [];
 
         foreach (object?[] combination in combinatorialTestCases)
         {
-            for (int i = 0; i < combination.Length; i++)
-            {
-                possibleValues[i].Add(combination[i]);
-            }
+            possiblePairs.Add((combination[firstParameterIndex], combination[secondParameterIndex]));
         }
 
-        return possibleValues;
+        return possiblePairs;
     }
 
     private static IEnumerable<object[]> GetData(DataAttribute dataAttribute, [CallerMemberName] string? testMethodName = null)
@@ -255,6 +324,15 @@ public class CombinatorialDataAttributeTests
 
     private void SomeTestWithCustomValues([CustomValues] int a)
     {
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    private class ExcludeFirstParameterTrueAttribute : ExcludeTestCaseAttribute
+    {
+        public ExcludeFirstParameterTrueAttribute()
+            : base(true, typeof(AnyDataValue))
+        {
+        }
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]


### PR DESCRIPTION
`CombinatorialDataAttribute` and `PairwiseDataAttribute` now support suppressing known-invalid parameter combinations before xUnit enumerates them. Pairwise generation also considers exclusions while selecting rows, so it can choose allowed alternatives when feasible.

- **New exclusion API**
  - Added `ExcludeTestCaseAttribute(params object?[] arguments)`.
  - Added `typeof(AnyDataValue)` as a wildcard sentinel for a parameter position.
  - Validates that exclusion argument count matches the test method parameter count.

- **Combinatorial generation**
  - Filters excluded full combinations from `CombinatorialDataAttribute`.

- **Pairwise generation**
  - Threads an allow predicate through `PairwiseStrategy`.
  - Avoids vetoed rows during candidate generation/maximization.
  - Falls back to searching for an allowed alternative that still covers the required tuple when possible.
  - Drops only tuples that cannot be covered by any allowed row.

- **Coverage validation**
  - Added tests for exact exclusions, wildcard exclusions, and pairwise behavior under excluded combinations.

Example:

```csharp
[Theory]
[PairwiseData]
[ExcludeTestCase("windows", "arm64", typeof(AnyDataValue))]
public void BuildMatrix(
    [CombinatorialValues("windows", "linux")] string os,
    [CombinatorialValues("x64", "arm64")] string arch,
    bool optimized)
{
    // The invalid windows/arm64 cases are not generated.
}
```
