### PR TITLE
Merge latest Library.Template updates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.6.3",
+      "version": "7.6.4",
       "commands": [
         "pwsh"
       ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         - windows-2025
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites
@@ -75,7 +75,7 @@ jobs:
     name: 📃 Docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: 🔗 Markup Link Checker (mlc)
       uses: becheran/mlc@7ec24825cefe0c9c8c6bac48430e1f69e3ec356e # v1.2.0
       with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
     # You can define any steps you want, and they will run before the agent starts.
     # If you do not check out your code, Copilot will do this for you.
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: ⚙ Install prerequisites

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 

--- a/tools/artifacts/testResults.ps1
+++ b/tools/artifacts/testResults.ps1
@@ -6,12 +6,19 @@ $result = @{}
 
 $RepoRoot = Resolve-Path "$PSScriptRoot\..\.."
 $testRoot = Join-Path $RepoRoot test
-$result[$testRoot] = (Get-ChildItem "$testRoot\TestResults" -Recurse -Directory | Get-ChildItem -Recurse -File)
+$legacyTestResults = Join-Path $testRoot TestResults
+if (Test-Path $legacyTestResults) {
+    $result[$testRoot] = Get-ChildItem $legacyTestResults -Recurse -Directory |
+        Get-ChildItem -Recurse -File |
+        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '\\In\\' }
+}
 
 $artifactStaging = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
 $testlogsPath = Join-Path $artifactStaging "test_logs"
 if (Test-Path $testlogsPath) {
-    $result[$testlogsPath] = Get-ChildItem $testlogsPath -Recurse;
+    # Hang and crash dumps are copied into the TRX attachment directory.
+    $result[$testlogsPath] = Get-ChildItem $testlogsPath -Recurse |
+        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '\\In\\' }
 }
 
 $result


### PR DESCRIPTION
Keeps the repository aligned with the latest Library.Template maintenance updates so CI tooling and test artifact handling receive upstream fixes.

- Updates pinned workflow and .NET tool dependencies.
- Incorporates the test-results artifact fix that prevents duplicate dump artifacts.