### PR TITLE
Create fresh combinatorial member data for each test case

### DIFF
--- a/src/Xunit.Combinatorial/CombinatorialDataAttribute.cs
+++ b/src/Xunit.Combinatorial/CombinatorialDataAttribute.cs
@@ -36,16 +36,20 @@ public class CombinatorialDataAttribute : DataAttribute
             return new([]);
         }
 
-        var values = new List<object?>[parameters.Length];
+        var values = new object?[parameters.Length][];
         for (int i = 0; i < parameters.Length; i++)
         {
-            values[i] = ValuesUtilities.GetValuesFor(parameters[i]).ToList();
+            values[i] = ValuesUtilities.GetValuesFor(parameters[i]).ToArray();
         }
 
         ExcludeTestCaseAttribute[] exclusions = ExcludeTestCaseAttribute.GetExclusions(testMethod);
-        object[]? currentValues = new object[parameters.Length];
+        int[] currentValueIndices = new int[parameters.Length];
         return new(
-            [.. this.FillCombinations(parameters, values, currentValues, exclusions, 0).Select(v => new TheoryDataRow(v))]);
+            [..
+                this.FillCombinations(parameters, values, currentValueIndices, exclusions, 0)
+                    .Select(indices => new TheoryDataRow(indices.Select((valueIndex, parameterIndex) =>
+                        ValuesUtilities.GetValueForTestCase(parameters[parameterIndex], values[parameterIndex], valueIndex)).ToArray()))
+            ]);
     }
 
     /// <summary>
@@ -54,40 +58,37 @@ public class CombinatorialDataAttribute : DataAttribute
     /// </summary>
     /// <param name="parameters">The parameters taken by the test method.</param>
     /// <param name="candidateValues">An array of each argument's list of possible values.</param>
-    /// <param name="currentValues">An array that is being recursively initialized with a set of arguments to pass to the test method.</param>
+    /// <param name="currentValueIndices">An array that is being recursively initialized with the candidate value index for each argument.</param>
     /// <param name="exclusions">Test cases that should not be generated.</param>
-    /// <param name="index">The index into <paramref name="currentValues"/> that this particular invocation should rotate through <paramref name="candidateValues"/> for.</param>
-    /// <returns>A sequence of all combinations of arguments from <paramref name="candidateValues"/>, starting at <paramref name="index"/>.</returns>
-    private IEnumerable<object?[]> FillCombinations(ParameterInfo[] parameters, List<object?>[] candidateValues, object?[] currentValues, ExcludeTestCaseAttribute[] exclusions, int index)
+    /// <param name="index">The index into <paramref name="currentValueIndices"/> that this particular invocation should rotate through <paramref name="candidateValues"/> for.</param>
+    /// <returns>A sequence of all combinations of candidate value indices, starting at <paramref name="index"/>.</returns>
+    private IEnumerable<int[]> FillCombinations(ParameterInfo[] parameters, object?[][] candidateValues, int[] currentValueIndices, ExcludeTestCaseAttribute[] exclusions, int index)
     {
         Requires.NotNull(parameters, nameof(parameters));
         Requires.NotNull(candidateValues, nameof(candidateValues));
-        Requires.NotNull(currentValues, nameof(currentValues));
+        Requires.NotNull(currentValueIndices, nameof(currentValueIndices));
         Requires.NotNull(exclusions, nameof(exclusions));
         Requires.Argument(parameters.Length == candidateValues.Length, nameof(candidateValues), $"Expected to have same array length as {nameof(parameters)}");
-        Requires.Argument(parameters.Length == currentValues.Length, nameof(currentValues), $"Expected to have same array length as {nameof(parameters)}");
+        Requires.Argument(parameters.Length == currentValueIndices.Length, nameof(currentValueIndices), $"Expected to have same array length as {nameof(parameters)}");
         Requires.Range(index >= 0 && index < parameters.Length, nameof(index));
 
-        foreach (object? value in candidateValues[index])
+        for (int valueIndex = 0; valueIndex < candidateValues[index].Length; valueIndex++)
         {
-            currentValues[index] = value;
+            currentValueIndices[index] = valueIndex;
 
             if (index + 1 < parameters.Length)
             {
-                foreach (object?[] result in this.FillCombinations(parameters, candidateValues, currentValues, exclusions, index + 1))
+                foreach (int[] result in this.FillCombinations(parameters, candidateValues, currentValueIndices, exclusions, index + 1))
                 {
                     yield return result;
                 }
             }
             else
             {
-                // We're the tail end, so just produce the value.
-                // Copy the array before returning since we're about to mutate currentValues
-                object[] finalSet = new object[currentValues.Length];
-                Array.Copy(currentValues, finalSet, currentValues.Length);
-                if (!exclusions.Any(e => e.Matches(finalSet)))
+                object?[] finalSet = currentValueIndices.Select((candidateIndex, parameterIndex) => candidateValues[parameterIndex][candidateIndex]).ToArray();
+                if (!exclusions.Any(exclusion => exclusion.Matches(finalSet)))
                 {
-                    yield return finalSet;
+                    yield return [.. currentValueIndices];
                 }
             }
         }

--- a/src/Xunit.Combinatorial/PairwiseDataAttribute.cs
+++ b/src/Xunit.Combinatorial/PairwiseDataAttribute.cs
@@ -39,7 +39,8 @@ public class PairwiseDataAttribute : DataAttribute
         int[][] testCaseInfo = PairwiseStrategy.GetTestCases([.. values.Select(v => v.Length)], isTestCaseAllowed);
         IEnumerable<TheoryDataRow> intermediate =
             from testCase in testCaseInfo
-            select new TheoryDataRow(testCase.Select((j, i) => values[i][j]).ToArray());
+            select new TheoryDataRow(testCase.Select((valueIndex, parameterIndex) =>
+                ValuesUtilities.GetValueForTestCase(parameters[parameterIndex], values[parameterIndex], valueIndex)).ToArray());
         return new ValueTask<IReadOnlyCollection<ITheoryDataRow>>([.. intermediate]);
     }
 }

--- a/src/Xunit.Combinatorial/ValuesUtilities.cs
+++ b/src/Xunit.Combinatorial/ValuesUtilities.cs
@@ -30,6 +30,34 @@ internal static class ValuesUtilities
     }
 
     /// <summary>
+    /// Gets one candidate value for a generated test case, recreating member data so mutable values are not shared between test cases.
+    /// </summary>
+    /// <param name="parameter">The parameter to get a value for.</param>
+    /// <param name="candidateValues">The candidate values used to determine the test case combinations.</param>
+    /// <param name="candidateIndex">The index of the candidate value selected for the test case.</param>
+    /// <returns>The value to use for the generated test case.</returns>
+    internal static object? GetValueForTestCase(ParameterInfo parameter, object?[] candidateValues, int candidateIndex)
+    {
+        Requires.NotNull(parameter, nameof(parameter));
+        Requires.NotNull(candidateValues, nameof(candidateValues));
+
+        CombinatorialMemberDataAttribute? memberData = parameter.GetCustomAttributes().OfType<CombinatorialMemberDataAttribute>().SingleOrDefault();
+        if (memberData is null)
+        {
+            return candidateValues[candidateIndex];
+        }
+
+        object?[] freshValues = memberData.GetValues(parameter);
+        if (freshValues.Length != candidateValues.Length)
+        {
+            throw new InvalidOperationException(
+                $"Member data for parameter '{parameter.Name}' returned {candidateValues.Length} values when determining combinations, but {freshValues.Length} values when creating a test case.");
+        }
+
+        return freshValues[candidateIndex];
+    }
+
+    /// <summary>
     /// Gets a sequence of values that should be tested for the specified type.
     /// </summary>
     /// <param name="dataType">The type to get possible values for.</param>

--- a/test/Xunit.Combinatorial.Tests/CombinatorialDataAttributeTests.cs
+++ b/test/Xunit.Combinatorial.Tests/CombinatorialDataAttributeTests.cs
@@ -196,6 +196,28 @@ public class CombinatorialDataAttributeTests
             actual.Select(r => r.GetData()));
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetData_MemberDataValuesAreUniquePerTestCase(bool pairwise)
+    {
+        DataAttribute attribute = pairwise ? new PairwiseDataAttribute() : new CombinatorialDataAttribute();
+
+        IReadOnlyCollection<ITheoryDataRow> rows = await GetData(attribute);
+        MutableValue[] values = rows.Select(row => Assert.IsType<MutableValue>(row.GetData()[0])).ToArray();
+
+        Assert.Equal(4, values.Length);
+        Assert.Equal(2, values.Count(value => value.Value == 1));
+        Assert.Equal(2, values.Count(value => value.Value == 2));
+        for (int i = 0; i < values.Length; i++)
+        {
+            for (int j = i + 1; j < values.Length; j++)
+            {
+                Assert.NotSame(values[i], values[j]);
+            }
+        }
+    }
+
     private static void Suppose_NoArguments()
     {
     }
@@ -262,6 +284,18 @@ public class CombinatorialDataAttributeTests
 
     private static void Suppose_UnsupportedNullableType(Guid? p1)
     {
+    }
+
+    private static void Suppose_MemberDataValuesAreUniquePerTestCase(
+        [CombinatorialMemberData(nameof(GetMutableValues))] MutableValue value,
+        bool flag)
+    {
+    }
+
+    private static IEnumerable<MutableValue> GetMutableValues()
+    {
+        yield return new MutableValue(1);
+        yield return new MutableValue(2);
     }
 
     private static async Task AssertData(IReadOnlyCollection<object?[]> expectedCombinatorial, [CallerMemberName] string? testMethodName = null)
@@ -343,5 +377,22 @@ public class CombinatorialDataAttributeTests
             : base([5, 10, 15])
         {
         }
+    }
+
+    private class MutableValue
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MutableValue"/> class.
+        /// </summary>
+        /// <param name="value">The value that identifies the candidate position.</param>
+        internal MutableValue(int value)
+        {
+            this.Value = value;
+        }
+
+        /// <summary>
+        /// Gets the value that identifies the candidate position.
+        /// </summary>
+        internal int Value { get; }
     }
 }


### PR DESCRIPTION
`CombinatorialMemberData` currently shares candidate object instances across generated theory rows, which causes mutable values such as mocks to accumulate state between tests.

This change preserves candidate indices while generating combinatorial and pairwise cases, then re-evaluates member data as each row is materialized. Each test case receives a fresh object while retaining the originally selected candidate position and exclusion behavior. Regression coverage verifies both strategies produce unique instances with the expected candidate distribution.

Fixes #39