### PR TITLE
Expose public combinatorial generation APIs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Validation" Version="2.6.68" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />

--- a/docfx/docs/custom-generation.md
+++ b/docfx/docs/custom-generation.md
@@ -1,0 +1,69 @@
+# Generating custom theory data
+
+The parameter attributes in this package cover common cases, but ordinary xUnit member data is more expressive.
+<xref:Xunit.CombinatorialTestCaseGenerator> and <xref:Xunit.CombinatorialTheoryDataBuilder> expose the same generation capabilities for use in your own fields, properties, and methods.
+
+## Mix hand-authored rows with generated columns
+
+Use <xref:Xunit.CombinatorialTheoryDataBuilder.AddRows(System.ReadOnlySpan{System.Object[]})> to establish a table of correlated base values.
+Each call to <xref:Xunit.CombinatorialTheoryDataBuilder.AddValues``1(System.ReadOnlySpan{``0})> adds one generated column.
+Passing an array to `AddValues` treats each array element as a candidate value for that column.
+
+[!code-csharp[](../../samples/CustomGeneration.cs#MixedGeneratedData)]
+
+The base table contains the `(10, 0)` and `(5, 2)` rows.
+The Boolean candidates are spread across both rows, producing four combinations.
+<xref:Xunit.CombinatorialTheoryDataBuilder.AddTestCase(System.ReadOnlySpan{System.Object})> appends the bespoke `(6, 2, false)` case without expanding it.
+
+Call `AddRows` before the first `AddValues` call.
+Additional `AddRows` calls append complete rows with the same width as the original base table.
+Explicit test cases must match the final width after all generated columns are added.
+
+## Constrain generated rows
+
+<xref:Xunit.CombinatorialTheoryDataBuilder.Where(Xunit.CombinatorialTheoryDataPredicate)> accepts a predicate over the completed row.
+Constraints are applied during generation, so pairwise generation can seek other rows that retain as much pair coverage as possible.
+Explicit rows added with `AddTestCase` are not constrained.
+
+[!code-csharp[](../../samples/CustomGeneration.cs#ConstrainedPairwiseData)]
+
+`BuildCombinations` returns the exhaustive Cartesian product.
+`BuildPairwiseCombinations` returns a smaller covering set.
+
+## Reproduce or vary pairwise results
+
+Pairwise generation is deterministic when its optional seed is omitted.
+Pass a stable integer seed to reproduce another covering set:
+
+```csharp
+IReadOnlyCollection<ITheoryDataRow> rows = ConstrainedPairwiseData.CreateCases(seed: 42);
+```
+
+To vary coverage between runs, generate a seed and record it with the test output so a failure can be reproduced:
+
+```csharp
+int seed = Random.Shared.Next();
+IReadOnlyCollection<ITheoryDataRow> rows = ConstrainedPairwiseData.CreateCases(seed);
+```
+
+Seeds apply only to pairwise generation.
+Exhaustive generation always returns the complete set in stable order.
+
+## Generate permutations
+
+<xref:Xunit.CombinatorialTestCaseGenerator.GeneratePermutations``1(System.ReadOnlySpan{``0})> returns every positional permutation of its input:
+
+[!code-csharp[](../../samples/CustomGeneration.cs#GeneratedPermutations)]
+
+Input positions are distinct.
+If the input contains equal values, equal output rows may therefore appear.
+
+## Work directly with dimension indices
+
+For complete control, use <xref:Xunit.CombinatorialTestCaseGenerator.GenerateCombinations(System.ReadOnlySpan{System.Int32},Xunit.CombinatorialIndexPredicate)> or <xref:Xunit.CombinatorialTestCaseGenerator.GeneratePairwiseCombinations(System.ReadOnlySpan{System.Int32},Xunit.CombinatorialIndexPredicate,System.Nullable{System.Int32})>.
+Each result contains one selected zero-based candidate index per dimension.
+
+[!code-csharp[](../../samples/CustomGeneration.cs#LowLevelGeneration)]
+
+Both methods accept an optional <xref:Xunit.CombinatorialIndexPredicate> that can reject index selections.
+Use the higher-level builder when you want constraints to inspect actual theory argument values instead.

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -3,3 +3,4 @@ items:
 - href: combinatorial-vs-pairwise.md
 - href: exclude-test-cases.md
 - href: value-sources.md
+- href: custom-generation.md

--- a/docfx/docs/value-sources.md
+++ b/docfx/docs/value-sources.md
@@ -59,3 +59,7 @@ The @Xunit.CombinatorialRandomDataAttribute can be applied to theory parameters 
 The min, max, and number of values can all be set via named parameters.
 
 [!code-csharp[](../../samples/ValueSources.cs#CombinatorialRandomData)]
+
+## Custom member data generation
+
+For correlated hand-authored rows, generated columns, permutations, constraints, or seeded pairwise generation, see [Generating custom theory data](custom-generation.md).

--- a/samples/CustomGeneration.cs
+++ b/samples/CustomGeneration.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+
+public class MixedGeneratedData
+{
+    #region MixedGeneratedData
+    public static IReadOnlyCollection<ITheoryDataRow> Cases =>
+        new CombinatorialTheoryDataBuilder()
+            .AddRows([10, 0], [5, 2])
+            .AddValues(true, false)
+            .AddTestCase(6, 2, false)
+            .BuildCombinations();
+
+    [Theory, MemberData(nameof(Cases))]
+    public void Example(int a, int b, bool c)
+    {
+        Assert.True(a > b);
+    }
+    #endregion
+}
+
+public class GeneratedPermutations
+{
+    #region GeneratedPermutations
+    public static IEnumerable<object?[]> Permutations =>
+        CombinatorialTestCaseGenerator.GeneratePermutations([1, 2, 3])
+            .Select(permutation => new object?[] { permutation });
+
+    [Theory, MemberData(nameof(Permutations))]
+    public void Example(int[] values)
+    {
+        Assert.Equal(3, values.Length);
+    }
+    #endregion
+}
+
+public class ConstrainedPairwiseData
+{
+    #region ConstrainedPairwiseData
+    public static IReadOnlyCollection<ITheoryDataRow> CreateCases(int? seed = null)
+    {
+        return new CombinatorialTheoryDataBuilder()
+            .AddValues(0, 1, 2)
+            .AddValues("small", "large")
+            .AddValues(false, true)
+            .Where(row => !Equals(row[0], 0) || !Equals(row[1], "large"))
+            .BuildPairwiseCombinations(seed);
+    }
+    #endregion
+}
+
+public class LowLevelGeneration
+{
+    #region LowLevelGeneration
+    public static IEnumerable<object?[]> Cases
+    {
+        get
+        {
+            string[] operatingSystems = ["Windows", "Linux"];
+            int[] runtimes = [8, 9, 10];
+            foreach (int[] selection in CombinatorialTestCaseGenerator.GeneratePairwiseCombinations(
+                [operatingSystems.Length, runtimes.Length]))
+            {
+                yield return [operatingSystems[selection[0]], runtimes[selection[1]]];
+            }
+        }
+    }
+    #endregion
+}

--- a/src/Xunit.Combinatorial/CombinatorialDataAttribute.cs
+++ b/src/Xunit.Combinatorial/CombinatorialDataAttribute.cs
@@ -43,54 +43,13 @@ public class CombinatorialDataAttribute : DataAttribute
         }
 
         ExcludeTestCaseAttribute[] exclusions = ExcludeTestCaseAttribute.GetExclusions(testMethod);
-        int[] currentValueIndices = new int[parameters.Length];
+        CombinatorialIndexPredicate? isTestCaseAllowed = ExcludeTestCaseAttribute.CreateIndexMatcher(values, exclusions);
+        int[][] testCases = CombinatorialTestCaseGenerator.GenerateCombinations([.. values.Select(v => v.Length)], isTestCaseAllowed);
         return new(
             [..
-                this.FillCombinations(parameters, values, currentValueIndices, exclusions, 0)
+                testCases
                     .Select(indices => new TheoryDataRow(indices.Select((valueIndex, parameterIndex) =>
                         ValuesUtilities.GetValueForTestCase(parameters[parameterIndex], values[parameterIndex], valueIndex)).ToArray()))
             ]);
-    }
-
-    /// <summary>
-    /// Produces a sequence of argument arrays that capture every possible
-    /// combination of values.
-    /// </summary>
-    /// <param name="parameters">The parameters taken by the test method.</param>
-    /// <param name="candidateValues">An array of each argument's list of possible values.</param>
-    /// <param name="currentValueIndices">An array that is being recursively initialized with the candidate value index for each argument.</param>
-    /// <param name="exclusions">Test cases that should not be generated.</param>
-    /// <param name="index">The index into <paramref name="currentValueIndices"/> that this particular invocation should rotate through <paramref name="candidateValues"/> for.</param>
-    /// <returns>A sequence of all combinations of candidate value indices, starting at <paramref name="index"/>.</returns>
-    private IEnumerable<int[]> FillCombinations(ParameterInfo[] parameters, object?[][] candidateValues, int[] currentValueIndices, ExcludeTestCaseAttribute[] exclusions, int index)
-    {
-        Requires.NotNull(parameters, nameof(parameters));
-        Requires.NotNull(candidateValues, nameof(candidateValues));
-        Requires.NotNull(currentValueIndices, nameof(currentValueIndices));
-        Requires.NotNull(exclusions, nameof(exclusions));
-        Requires.Argument(parameters.Length == candidateValues.Length, nameof(candidateValues), $"Expected to have same array length as {nameof(parameters)}");
-        Requires.Argument(parameters.Length == currentValueIndices.Length, nameof(currentValueIndices), $"Expected to have same array length as {nameof(parameters)}");
-        Requires.Range(index >= 0 && index < parameters.Length, nameof(index));
-
-        for (int valueIndex = 0; valueIndex < candidateValues[index].Length; valueIndex++)
-        {
-            currentValueIndices[index] = valueIndex;
-
-            if (index + 1 < parameters.Length)
-            {
-                foreach (int[] result in this.FillCombinations(parameters, candidateValues, currentValueIndices, exclusions, index + 1))
-                {
-                    yield return result;
-                }
-            }
-            else
-            {
-                object?[] finalSet = currentValueIndices.Select((candidateIndex, parameterIndex) => candidateValues[parameterIndex][candidateIndex]).ToArray();
-                if (!exclusions.Any(exclusion => exclusion.Matches(finalSet)))
-                {
-                    yield return [.. currentValueIndices];
-                }
-            }
-        }
     }
 }

--- a/src/Xunit.Combinatorial/CombinatorialTestCaseGenerator.cs
+++ b/src/Xunit.Combinatorial/CombinatorialTestCaseGenerator.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+namespace Xunit;
+
+/// <summary>
+/// Determines whether a generated test case, represented by one selected value index per dimension, is allowed.
+/// </summary>
+/// <param name="indices">The selected zero-based value index for each dimension.</param>
+/// <returns><see langword="true"/> if the test case is allowed; otherwise, <see langword="false"/>.</returns>
+public delegate bool CombinatorialIndexPredicate(ReadOnlySpan<int> indices);
+
+/// <summary>
+/// Generates exhaustive, pairwise, and permutation test cases.
+/// </summary>
+public static class CombinatorialTestCaseGenerator
+{
+    private const int DefaultPairwiseSeed = 15485863;
+
+    /// <summary>
+    /// Generates every possible combination of value indices across the specified dimensions.
+    /// </summary>
+    /// <param name="dimensionSizes">The number of candidate values in each dimension.</param>
+    /// <param name="isTestCaseAllowed">An optional predicate that rejects test cases.</param>
+    /// <returns>One test case per array, with one selected value index per dimension.</returns>
+    public static int[][] GenerateCombinations(
+        ReadOnlySpan<int> dimensionSizes,
+        CombinatorialIndexPredicate? isTestCaseAllowed = null)
+    {
+        int[] dimensions = ValidateAndCopyDimensions(dimensionSizes);
+        if (dimensions.Length == 0 || dimensions.Contains(0))
+        {
+            return [];
+        }
+
+        List<int[]> results = [];
+        int[] current = new int[dimensions.Length];
+        FillCombinations(dimensions, current, 0, isTestCaseAllowed, results);
+        return results.ToArray();
+    }
+
+    /// <summary>
+    /// Generates test cases that cover every possible pair of value indices across the specified dimensions.
+    /// </summary>
+    /// <param name="dimensionSizes">The number of candidate values in each dimension.</param>
+    /// <param name="isTestCaseAllowed">An optional predicate that rejects test cases.</param>
+    /// <param name="seed">An optional seed used to vary the generated covering set. Omit to preserve the default deterministic result.</param>
+    /// <returns>One test case per array, with one selected value index per dimension.</returns>
+    public static int[][] GeneratePairwiseCombinations(
+        ReadOnlySpan<int> dimensionSizes,
+        CombinatorialIndexPredicate? isTestCaseAllowed = null,
+        int? seed = null)
+    {
+        int[] dimensions = ValidateAndCopyDimensions(dimensionSizes);
+        if (dimensions.Length == 0 || dimensions.Contains(0))
+        {
+            return [];
+        }
+
+        return PairwiseStrategy.GetTestCases(dimensions, isTestCaseAllowed, seed ?? DefaultPairwiseSeed);
+    }
+
+    /// <summary>
+    /// Generates every permutation of the supplied values.
+    /// </summary>
+    /// <typeparam name="T">The type of value to permute.</typeparam>
+    /// <param name="values">The values to permute.</param>
+    /// <returns>Every positional permutation of <paramref name="values"/>.</returns>
+    /// <remarks>Input positions are treated as distinct, so equal input values may produce equal output rows.</remarks>
+    public static T[][] GeneratePermutations<T>(ReadOnlySpan<T> values)
+    {
+        if (values.Length == 0)
+        {
+            return [];
+        }
+
+        T[] valueCopy = values.ToArray();
+        List<T[]> results = [];
+        FillPermutations(valueCopy, new T[valueCopy.Length], new bool[valueCopy.Length], 0, results);
+        return results.ToArray();
+    }
+
+    private static void FillPermutations<T>(
+        T[] values,
+        T[] current,
+        bool[] usedIndices,
+        int outputIndex,
+        List<T[]> results)
+    {
+        if (outputIndex == current.Length)
+        {
+            results.Add([.. current]);
+            return;
+        }
+
+        for (int valueIndex = 0; valueIndex < values.Length; valueIndex++)
+        {
+            if (usedIndices[valueIndex])
+            {
+                continue;
+            }
+
+            usedIndices[valueIndex] = true;
+            current[outputIndex] = values[valueIndex];
+            FillPermutations(values, current, usedIndices, outputIndex + 1, results);
+            usedIndices[valueIndex] = false;
+        }
+    }
+
+    private static void FillCombinations(
+        int[] dimensions,
+        int[] current,
+        int dimension,
+        CombinatorialIndexPredicate? isTestCaseAllowed,
+        List<int[]> results)
+    {
+        for (int valueIndex = 0; valueIndex < dimensions[dimension]; valueIndex++)
+        {
+            current[dimension] = valueIndex;
+            if (dimension + 1 < dimensions.Length)
+            {
+                FillCombinations(dimensions, current, dimension + 1, isTestCaseAllowed, results);
+            }
+            else if (isTestCaseAllowed?.Invoke(current) ?? true)
+            {
+                results.Add([.. current]);
+            }
+        }
+    }
+
+    private static int[] ValidateAndCopyDimensions(ReadOnlySpan<int> dimensionSizes)
+    {
+        int[] dimensions = dimensionSizes.ToArray();
+        for (int i = 0; i < dimensions.Length; i++)
+        {
+            if (dimensions[i] < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(dimensionSizes), dimensions[i], "Dimension sizes cannot be negative.");
+            }
+        }
+
+        return dimensions;
+    }
+}

--- a/src/Xunit.Combinatorial/CombinatorialTheoryDataBuilder.cs
+++ b/src/Xunit.Combinatorial/CombinatorialTheoryDataBuilder.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit.Sdk;
+using Xunit.v3;
+
+namespace Xunit;
+
+/// <summary>
+/// Determines whether a generated theory data row is allowed.
+/// </summary>
+/// <param name="values">The values in the completed theory data row.</param>
+/// <returns><see langword="true"/> if the row is allowed; otherwise, <see langword="false"/>.</returns>
+public delegate bool CombinatorialTheoryDataPredicate(ReadOnlySpan<object?> values);
+
+/// <summary>
+/// Builds xUnit theory data from hand-authored base rows and generated columns.
+/// </summary>
+public sealed class CombinatorialTheoryDataBuilder
+{
+    private readonly List<object?[]> baseRows = [];
+    private readonly List<object?[]> generatedColumns = [];
+    private readonly List<object?[]> explicitTestCases = [];
+    private readonly List<CombinatorialTheoryDataPredicate> predicates = [];
+    private int? baseColumnCount;
+
+    /// <summary>
+    /// Adds complete hand-authored rows for the base columns.
+    /// </summary>
+    /// <param name="rows">The rows to add. Every row must have the same width.</param>
+    /// <returns>This builder.</returns>
+    public CombinatorialTheoryDataBuilder AddRows(params ReadOnlySpan<object?[]> rows)
+    {
+        if (rows.Length == 0)
+        {
+            throw new ArgumentException("At least one row is required.", nameof(rows));
+        }
+
+        this.EnsureBaseRowsMayBeAdded();
+        for (int i = 0; i < rows.Length; i++)
+        {
+            if (rows[i] is null)
+            {
+                throw new ArgumentException("Base rows cannot be null.", nameof(rows));
+            }
+
+            this.AddBaseRow(rows[i]);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds complete hand-authored rows for the base columns.
+    /// </summary>
+    /// <param name="rows">The rows to add. Every row must have the same width.</param>
+    /// <returns>This builder.</returns>
+    public CombinatorialTheoryDataBuilder AddRows(IEnumerable<IReadOnlyList<object?>> rows)
+    {
+        Requires.NotNull(rows, nameof(rows));
+        this.EnsureBaseRowsMayBeAdded();
+
+        bool any = false;
+        foreach (IReadOnlyList<object?> row in rows)
+        {
+            if (row is null)
+            {
+                throw new ArgumentException("Base rows cannot be null.", nameof(rows));
+            }
+
+            any = true;
+            object?[] rowCopy = new object?[row.Count];
+            for (int i = 0; i < row.Count; i++)
+            {
+                rowCopy[i] = row[i];
+            }
+
+            this.AddBaseRow(rowCopy);
+        }
+
+        if (!any)
+        {
+            throw new ArgumentException("At least one row is required.", nameof(rows));
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a generated column with the specified candidate values.
+    /// </summary>
+    /// <typeparam name="T">The type of values in the column.</typeparam>
+    /// <param name="values">The candidate values for the column.</param>
+    /// <returns>This builder.</returns>
+    public CombinatorialTheoryDataBuilder AddValues<T>(params ReadOnlySpan<T> values)
+    {
+        if (values.Length == 0)
+        {
+            throw new ArgumentException("At least one value is required.", nameof(values));
+        }
+
+        object?[] valuesCopy = new object?[values.Length];
+        for (int i = 0; i < values.Length; i++)
+        {
+            valuesCopy[i] = values[i];
+        }
+
+        this.generatedColumns.Add(valuesCopy);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a generated column with the specified candidate values.
+    /// </summary>
+    /// <typeparam name="T">The type of values in the column.</typeparam>
+    /// <param name="values">The candidate values for the column.</param>
+    /// <returns>This builder.</returns>
+    public CombinatorialTheoryDataBuilder AddValues<T>(IEnumerable<T> values)
+    {
+        Requires.NotNull(values, nameof(values));
+        object?[] valuesCopy = values.Cast<object?>().ToArray();
+        if (valuesCopy.Length == 0)
+        {
+            throw new ArgumentException("At least one value is required.", nameof(values));
+        }
+
+        this.generatedColumns.Add(valuesCopy);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a complete hand-authored test case after the generated rows.
+    /// </summary>
+    /// <param name="values">The values in the test case.</param>
+    /// <returns>This builder.</returns>
+    public CombinatorialTheoryDataBuilder AddTestCase(params ReadOnlySpan<object?> values)
+    {
+        this.explicitTestCases.Add(values.ToArray());
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a constraint that generated test cases must satisfy.
+    /// </summary>
+    /// <param name="isTestCaseAllowed">The predicate to evaluate against completed generated rows.</param>
+    /// <returns>This builder.</returns>
+    public CombinatorialTheoryDataBuilder Where(CombinatorialTheoryDataPredicate isTestCaseAllowed)
+    {
+        Requires.NotNull(isTestCaseAllowed, nameof(isTestCaseAllowed));
+        this.predicates.Add(isTestCaseAllowed);
+        return this;
+    }
+
+    /// <summary>
+    /// Builds every possible combination of the configured base rows and generated columns.
+    /// </summary>
+    /// <returns>The generated rows followed by explicitly added test cases.</returns>
+    public IReadOnlyCollection<ITheoryDataRow> BuildCombinations()
+    {
+        return this.Build(pairwise: false, seed: null);
+    }
+
+    /// <summary>
+    /// Builds rows that cover every possible pair across the configured base rows and generated columns.
+    /// </summary>
+    /// <param name="seed">An optional seed used to vary the generated covering set. Omit for deterministic results.</param>
+    /// <returns>The generated rows followed by explicitly added test cases.</returns>
+    public IReadOnlyCollection<ITheoryDataRow> BuildPairwiseCombinations(int? seed = null)
+    {
+        return this.Build(pairwise: true, seed);
+    }
+
+    private void AddBaseRow(ReadOnlySpan<object?> row)
+    {
+        if (this.baseColumnCount is int expectedWidth && row.Length != expectedWidth)
+        {
+            throw new ArgumentException($"Expected a base row with {expectedWidth} values, but found {row.Length}.", nameof(row));
+        }
+
+        this.baseColumnCount ??= row.Length;
+        this.baseRows.Add(row.ToArray());
+    }
+
+    private IReadOnlyCollection<ITheoryDataRow> Build(bool pairwise, int? seed)
+    {
+        int totalColumns = (this.baseColumnCount ?? 0) + this.generatedColumns.Count;
+        foreach (object?[] testCase in this.explicitTestCases)
+        {
+            if (testCase.Length != totalColumns)
+            {
+                throw new InvalidOperationException($"Expected explicit test cases to have {totalColumns} values, but found {testCase.Length}.");
+            }
+        }
+
+        List<object?[]> dimensions = [];
+        if (this.baseRows.Count > 0)
+        {
+            dimensions.Add(this.baseRows.Cast<object?>().ToArray());
+        }
+
+        dimensions.AddRange(this.generatedColumns);
+        int[] dimensionSizes = dimensions.Select(dimension => dimension.Length).ToArray();
+        CombinatorialIndexPredicate? indexPredicate = this.predicates.Count == 0
+            ? null
+            : indices => this.IsAllowed(dimensions, indices);
+        int[][] selections = pairwise
+            ? CombinatorialTestCaseGenerator.GeneratePairwiseCombinations(dimensionSizes, indexPredicate, seed)
+            : CombinatorialTestCaseGenerator.GenerateCombinations(dimensionSizes, indexPredicate);
+
+        List<ITheoryDataRow> results = new(selections.Length + this.explicitTestCases.Count);
+        foreach (int[] selection in selections)
+        {
+            results.Add(new TheoryDataRow(this.Flatten(dimensions, selection)));
+        }
+
+        foreach (object?[] testCase in this.explicitTestCases)
+        {
+            results.Add(new TheoryDataRow([.. testCase]));
+        }
+
+        return results;
+    }
+
+    private void EnsureBaseRowsMayBeAdded()
+    {
+        if (this.generatedColumns.Count > 0)
+        {
+            throw new InvalidOperationException($"{nameof(this.AddRows)} must be called before {nameof(this.AddValues)}.");
+        }
+    }
+
+    private object?[] Flatten(List<object?[]> dimensions, ReadOnlySpan<int> indices)
+    {
+        int outputLength = (this.baseColumnCount ?? 0) + this.generatedColumns.Count;
+        object?[] values = new object?[outputLength];
+        int outputIndex = 0;
+        int dimensionIndex = 0;
+
+        if (this.baseRows.Count > 0)
+        {
+            object?[] baseRow = this.baseRows[indices[dimensionIndex]];
+            Array.Copy(baseRow, 0, values, 0, baseRow.Length);
+            outputIndex += baseRow.Length;
+            dimensionIndex++;
+        }
+
+        for (; dimensionIndex < dimensions.Count; dimensionIndex++)
+        {
+            values[outputIndex++] = dimensions[dimensionIndex][indices[dimensionIndex]];
+        }
+
+        return values;
+    }
+
+    private bool IsAllowed(List<object?[]> dimensions, ReadOnlySpan<int> indices)
+    {
+        object?[] values = this.Flatten(dimensions, indices);
+        foreach (CombinatorialTheoryDataPredicate predicate in this.predicates)
+        {
+            if (!predicate(values))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Xunit.Combinatorial/ExcludeTestCaseAttribute.cs
+++ b/src/Xunit.Combinatorial/ExcludeTestCaseAttribute.cs
@@ -53,7 +53,7 @@ public class ExcludeTestCaseAttribute : Attribute
     /// <param name="candidateValues">The possible values for each parameter position.</param>
     /// <param name="exclusions">The exclusions to evaluate against indexed test cases.</param>
     /// <returns>A predicate that returns <see langword="true"/> when a test case is allowed.</returns>
-    internal static Predicate<int[]>? CreateIndexMatcher(object?[][] candidateValues, ExcludeTestCaseAttribute[] exclusions)
+    internal static CombinatorialIndexPredicate? CreateIndexMatcher(object?[][] candidateValues, ExcludeTestCaseAttribute[] exclusions)
     {
         Requires.NotNull(candidateValues, nameof(candidateValues));
         Requires.NotNull(exclusions, nameof(exclusions));
@@ -80,8 +80,6 @@ public class ExcludeTestCaseAttribute : Attribute
 
         return testCase =>
         {
-            Requires.NotNull(testCase, nameof(testCase));
-
             foreach (IndexedExclusion exclusion in indexedExclusions)
             {
                 if (exclusion.Matches(testCase))
@@ -163,9 +161,8 @@ public class ExcludeTestCaseAttribute : Attribute
             return new IndexedExclusion(matchingValueIndices);
         }
 
-        internal bool Matches(int[] testCase)
+        internal bool Matches(ReadOnlySpan<int> testCase)
         {
-            Requires.NotNull(testCase, nameof(testCase));
             Requires.Argument(this.matchingValueIndices.Length == testCase.Length, nameof(testCase), $"Expected to have same array length as {nameof(this.matchingValueIndices)}");
 
             for (int parameterIndex = 0; parameterIndex < testCase.Length; parameterIndex++)

--- a/src/Xunit.Combinatorial/PairwiseDataAttribute.cs
+++ b/src/Xunit.Combinatorial/PairwiseDataAttribute.cs
@@ -35,8 +35,8 @@ public class PairwiseDataAttribute : DataAttribute
         }
 
         ExcludeTestCaseAttribute[] exclusions = ExcludeTestCaseAttribute.GetExclusions(testMethod);
-        Predicate<int[]>? isTestCaseAllowed = ExcludeTestCaseAttribute.CreateIndexMatcher(values, exclusions);
-        int[][] testCaseInfo = PairwiseStrategy.GetTestCases([.. values.Select(v => v.Length)], isTestCaseAllowed);
+        CombinatorialIndexPredicate? isTestCaseAllowed = ExcludeTestCaseAttribute.CreateIndexMatcher(values, exclusions);
+        int[][] testCaseInfo = CombinatorialTestCaseGenerator.GeneratePairwiseCombinations([.. values.Select(v => v.Length)], isTestCaseAllowed);
         IEnumerable<TheoryDataRow> intermediate =
             from testCase in testCaseInfo
             select new TheoryDataRow(testCase.Select((valueIndex, parameterIndex) =>

--- a/src/Xunit.Combinatorial/PairwiseStrategy.cs
+++ b/src/Xunit.Combinatorial/PairwiseStrategy.cs
@@ -60,28 +60,14 @@ internal static class PairwiseStrategy
     /// An array which contains information about dimensions. Each element of
     /// this array represents a number of features in the specific dimension.
     /// </param>
-    /// <returns>
-    /// A set of test cases.
-    /// </returns>
-    public static int[][] GetTestCases(int[] dimensions)
-    {
-        return GetTestCases(dimensions, null);
-    }
-
-    /// <summary>
-    /// Creates a set of test cases for specified dimensions.
-    /// </summary>
-    /// <param name="dimensions">
-    /// An array which contains information about dimensions. Each element of
-    /// this array represents a number of features in the specific dimension.
-    /// </param>
     /// <param name="isTestCaseAllowed">A predicate that returns <see langword="true"/> when a generated test case is allowed.</param>
+    /// <param name="seed">The seed for the pseudo-random number generator.</param>
     /// <returns>
     /// A set of test cases.
     /// </returns>
-    public static int[][] GetTestCases(int[] dimensions, Predicate<int[]>? isTestCaseAllowed)
+    public static int[][] GetTestCases(int[] dimensions, CombinatorialIndexPredicate? isTestCaseAllowed, int seed)
     {
-        return (from testCase in new PairwiseTestCaseGenerator().GetTestCases(dimensions, isTestCaseAllowed)
+        return (from testCase in new PairwiseTestCaseGenerator().GetTestCases(dimensions, isTestCaseAllowed, seed)
                 select testCase.Features).ToArray();
     }
 
@@ -341,7 +327,7 @@ internal static class PairwiseStrategy
         /// <summary>
         /// A predicate that determines whether a generated test case satisfies caller-supplied constraints.
         /// </summary>
-        private Predicate<int[]>? isTestCaseAllowed;
+        private CombinatorialIndexPredicate? isTestCaseAllowed;
 
         /// <summary>
         /// Creates a set of test cases for specified dimensions.
@@ -351,12 +337,13 @@ internal static class PairwiseStrategy
         /// this array represents a number of features in the specific dimension.
         /// </param>
         /// <param name="isTestCaseAllowed">A predicate that returns <see langword="true"/> when a generated test case is allowed.</param>
+        /// <param name="seed">The seed for the pseudo-random number generator.</param>
         /// <returns>
         /// A set of test cases.
         /// </returns>
-        public List<TestCaseInfo> GetTestCases(int[] dimensions, Predicate<int[]>? isTestCaseAllowed)
+        public List<TestCaseInfo> GetTestCases(int[] dimensions, CombinatorialIndexPredicate? isTestCaseAllowed, int seed)
         {
-            this.prng = new FleaRand(15485863);
+            this.prng = new FleaRand(unchecked((uint)seed));
             this.dimensions = dimensions;
             this.isTestCaseAllowed = isTestCaseAllowed;
 

--- a/src/Xunit.Combinatorial/Xunit.Combinatorial.csproj
+++ b/src/Xunit.Combinatorial/Xunit.Combinatorial.csproj
@@ -16,6 +16,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Memory" />
     <PackageReference Include="xunit.v3.extensibility.core" VersionOverride="1.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Xunit.Combinatorial.Tests/CombinatorialTestCaseGeneratorTests.cs
+++ b/test/Xunit.Combinatorial.Tests/CombinatorialTestCaseGeneratorTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Xunit;
+using Xunit.Sdk;
+
+public class CombinatorialTestCaseGeneratorTests
+{
+    [Fact]
+    public void GenerateCombinations_ReturnsCartesianProductInStableOrder()
+    {
+        int[][] results = CombinatorialTestCaseGenerator.GenerateCombinations([2, 3]);
+
+        Assert.Equal(
+            [
+                [0, 0],
+                [0, 1],
+                [0, 2],
+                [1, 0],
+                [1, 1],
+                [1, 2],
+            ],
+            results);
+    }
+
+    [Fact]
+    public void GenerateCombinations_AppliesConstraint()
+    {
+        int[][] results = CombinatorialTestCaseGenerator.GenerateCombinations(
+            [3, 3],
+            indices => indices[0] < indices[1]);
+
+        Assert.Equal([[0, 1], [0, 2], [1, 2]], results);
+    }
+
+    [Theory]
+    [InlineData(new int[0])]
+    [InlineData(new[] { 2, 0, 3 })]
+    public void GenerateCombinations_EmptyDimensionProducesNoRows(int[] dimensions)
+    {
+        Assert.Empty(CombinatorialTestCaseGenerator.GenerateCombinations(dimensions));
+        Assert.Empty(CombinatorialTestCaseGenerator.GeneratePairwiseCombinations(dimensions));
+    }
+
+    [Fact]
+    public void GenerateCombinations_RejectsNegativeDimension()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CombinatorialTestCaseGenerator.GenerateCombinations([2, -1]));
+        Assert.Throws<ArgumentOutOfRangeException>(() => CombinatorialTestCaseGenerator.GeneratePairwiseCombinations([2, -1]));
+    }
+
+    [Fact]
+    public void GeneratePairwiseCombinations_DefaultSeedIsStable()
+    {
+        int[][] first = CombinatorialTestCaseGenerator.GeneratePairwiseCombinations([3, 4, 2, 3]);
+        int[][] second = CombinatorialTestCaseGenerator.GeneratePairwiseCombinations([3, 4, 2, 3]);
+
+        Assert.Equal(first, second);
+        AssertPairwiseCoverage(first, [3, 4, 2, 3]);
+    }
+
+    [Fact]
+    public void GeneratePairwiseCombinations_SeedIsRepeatableAndCanVaryCoveringSet()
+    {
+        int[][] first = CombinatorialTestCaseGenerator.GeneratePairwiseCombinations([3, 4, 2, 3], seed: 1);
+        int[][] repeated = CombinatorialTestCaseGenerator.GeneratePairwiseCombinations([3, 4, 2, 3], seed: 1);
+        int[][] second = CombinatorialTestCaseGenerator.GeneratePairwiseCombinations([3, 4, 2, 3], seed: 2);
+
+        Assert.Equal(first, repeated);
+        Assert.NotEqual(first, second);
+        AssertPairwiseCoverage(first, [3, 4, 2, 3]);
+        AssertPairwiseCoverage(second, [3, 4, 2, 3]);
+    }
+
+    [Fact]
+    public void GeneratePairwiseCombinations_ImpossibleConstraintProducesNoRows()
+    {
+        int[][] results = CombinatorialTestCaseGenerator.GeneratePairwiseCombinations([2, 2], _ => false);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void GeneratePairwiseCombinations_ConstraintPreservesPossiblePairCoverage()
+    {
+        int[][] results = CombinatorialTestCaseGenerator.GeneratePairwiseCombinations(
+            [2, 2, 2],
+            indices => indices[0] != 1 || indices[1] != 1);
+
+        Assert.All(results, indices => Assert.False(indices[0] == 1 && indices[1] == 1));
+        AssertPairwiseCoverage(
+            results,
+            [2, 2, 2],
+            indices => indices[0] != 1 || indices[1] != 1);
+    }
+
+    [Fact]
+    public void GeneratePermutations_ReturnsEveryPositionalPermutation()
+    {
+        int[][] results = CombinatorialTestCaseGenerator.GeneratePermutations([1, 2, 3]);
+
+        Assert.Equal(
+            [
+                [1, 2, 3],
+                [1, 3, 2],
+                [2, 1, 3],
+                [2, 3, 1],
+                [3, 1, 2],
+                [3, 2, 1],
+            ],
+            results);
+    }
+
+    [Fact]
+    public void GeneratePermutations_TreatsDuplicatePositionsAsDistinct()
+    {
+        int[][] results = CombinatorialTestCaseGenerator.GeneratePermutations([1, 1, 2]);
+
+        Assert.Equal(6, results.Length);
+        Assert.Equal(3, results.Distinct(ArrayEqualityComparer<int>.Instance).Count());
+    }
+
+    [Fact]
+    public void GeneratePermutations_EmptyInputProducesNoRows()
+    {
+        Assert.Empty(CombinatorialTestCaseGenerator.GeneratePermutations<int>([]));
+    }
+
+    [Fact]
+    public void PublicParamsOverloadsUseReadOnlySpan()
+    {
+        MethodInfo addRows = typeof(CombinatorialTheoryDataBuilder).GetMethod(
+            nameof(CombinatorialTheoryDataBuilder.AddRows),
+            [typeof(ReadOnlySpan<object?[]>)])!;
+        MethodInfo addValues = typeof(CombinatorialTheoryDataBuilder).GetMethods()
+            .Single(method =>
+                method.Name == nameof(CombinatorialTheoryDataBuilder.AddValues) &&
+                method.IsGenericMethod &&
+                method.GetParameters()[0].ParameterType.IsGenericType &&
+                method.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>));
+        MethodInfo addTestCase = typeof(CombinatorialTheoryDataBuilder).GetMethod(
+            nameof(CombinatorialTheoryDataBuilder.AddTestCase),
+            [typeof(ReadOnlySpan<object?>)])!;
+
+        Assert.Equal(typeof(ReadOnlySpan<object?[]>), addRows.GetParameters()[0].ParameterType);
+        Assert.Equal(typeof(ReadOnlySpan<>), addValues.GetParameters()[0].ParameterType.GetGenericTypeDefinition());
+        Assert.Equal(typeof(ReadOnlySpan<object?>), addTestCase.GetParameters()[0].ParameterType);
+        AssertParamsCollection(addRows);
+        AssertParamsCollection(addValues);
+        AssertParamsCollection(addTestCase);
+    }
+
+    private static void AssertPairwiseCoverage(
+        int[][] results,
+        int[] dimensions,
+        CombinatorialIndexPredicate? isAllowed = null)
+    {
+        for (int firstDimension = 0; firstDimension < dimensions.Length - 1; firstDimension++)
+        {
+            for (int secondDimension = firstDimension + 1; secondDimension < dimensions.Length; secondDimension++)
+            {
+                for (int firstValue = 0; firstValue < dimensions[firstDimension]; firstValue++)
+                {
+                    for (int secondValue = 0; secondValue < dimensions[secondDimension]; secondValue++)
+                    {
+                        bool pairIsPossible = CombinatorialTestCaseGenerator.GenerateCombinations(
+                            dimensions,
+                            indices =>
+                                indices[firstDimension] == firstValue &&
+                                indices[secondDimension] == secondValue &&
+                                (isAllowed?.Invoke(indices) ?? true)).Length > 0;
+                        if (pairIsPossible)
+                        {
+                            Assert.Contains(
+                                results,
+                                row => row[firstDimension] == firstValue && row[secondDimension] == secondValue);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static void AssertParamsCollection(MethodInfo method)
+    {
+        Assert.Contains(
+            method.GetParameters()[0].GetCustomAttributesData(),
+            attribute => attribute.AttributeType.FullName == "System.Runtime.CompilerServices.ParamCollectionAttribute");
+    }
+
+    private sealed class ArrayEqualityComparer<T> : IEqualityComparer<T[]>
+    {
+        internal static readonly ArrayEqualityComparer<T> Instance = new();
+
+        public bool Equals(T[]? x, T[]? y) => x is not null && y is not null && x.SequenceEqual(y);
+
+        public int GetHashCode(T[] obj)
+        {
+            int hashCode = 17;
+            foreach (T value in obj)
+            {
+                hashCode = (hashCode * 31) + EqualityComparer<T>.Default.GetHashCode(value!);
+            }
+
+            return hashCode;
+        }
+    }
+}

--- a/test/Xunit.Combinatorial.Tests/CombinatorialTheoryDataBuilderTests.cs
+++ b/test/Xunit.Combinatorial.Tests/CombinatorialTheoryDataBuilderTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the Ms-PL license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Xunit.Sdk;
+
+public class CombinatorialTheoryDataBuilderTests
+{
+    [Fact]
+    public void BuildCombinations_ExpandsGeneratedColumnsAcrossBaseRows()
+    {
+        IReadOnlyCollection<ITheoryDataRow> results = new CombinatorialTheoryDataBuilder()
+            .AddRows([10, 0], [5, 2])
+            .AddValues(true, false)
+            .AddTestCase(6, 2, false)
+            .BuildCombinations();
+
+        Assert.Equal(
+            [
+                [10, 0, true],
+                [10, 0, false],
+                [5, 2, true],
+                [5, 2, false],
+                [6, 2, false],
+            ],
+            results.Select(row => row.GetData()));
+    }
+
+    [Fact]
+    public void BuildCombinations_CanGenerateColumnsWithoutBaseRows()
+    {
+        IReadOnlyCollection<ITheoryDataRow> results = new CombinatorialTheoryDataBuilder()
+            .AddValues(1, 2)
+            .AddValues("a", "b")
+            .BuildCombinations();
+
+        Assert.Equal(
+            [
+                [1, "a"],
+                [1, "b"],
+                [2, "a"],
+                [2, "b"],
+            ],
+            results.Select(row => row.GetData()));
+    }
+
+    [Fact]
+    public void BuildCombinations_MultipleAddRowsCallsAppendBaseRows()
+    {
+        IReadOnlyCollection<ITheoryDataRow> results = new CombinatorialTheoryDataBuilder()
+            .AddRows([1, 2])
+            .AddRows([3, 4])
+            .AddValues(false, true)
+            .BuildCombinations();
+
+        Assert.Equal(4, results.Count);
+        Assert.Contains(results, row => row.GetData().SequenceEqual([3, 4, true]));
+    }
+
+    [Fact]
+    public void BuildCombinations_AppliesAllConstraintsOnlyToGeneratedRows()
+    {
+        IReadOnlyCollection<ITheoryDataRow> results = new CombinatorialTheoryDataBuilder()
+            .AddRows([10, 0], [5, 2])
+            .AddValues(true, false)
+            .Where(row => (int)row[0]! > 5)
+            .Where(row => (bool)row[2]!)
+            .AddTestCase(1, 2, false)
+            .BuildCombinations();
+
+        Assert.Equal([[10, 0, true], [1, 2, false]], results.Select(row => row.GetData()));
+    }
+
+    [Fact]
+    public void BuildPairwiseCombinations_CoversPairsAcrossBaseRowsAndColumns()
+    {
+        IReadOnlyCollection<ITheoryDataRow> results = new CombinatorialTheoryDataBuilder()
+            .AddRows([10, 0], [5, 2], [8, 3])
+            .AddValues("a", "b", "c")
+            .AddValues(false, true)
+            .BuildPairwiseCombinations(seed: 42);
+
+        object?[][] rows = results.Select(row => row.GetData()).ToArray();
+        foreach (int firstBaseValue in new[] { 10, 5, 8 })
+        {
+            foreach (string text in new[] { "a", "b", "c" })
+            {
+                Assert.Contains(rows, row => Equals(row[0], firstBaseValue) && Equals(row[2], text));
+            }
+
+            foreach (bool flag in new[] { false, true })
+            {
+                Assert.Contains(rows, row => Equals(row[0], firstBaseValue) && Equals(row[3], flag));
+            }
+        }
+    }
+
+    [Fact]
+    public void BuildPairwiseCombinations_AppliesConstraint()
+    {
+        IReadOnlyCollection<ITheoryDataRow> results = new CombinatorialTheoryDataBuilder()
+            .AddValues(0, 1, 2)
+            .AddValues("small", "large")
+            .AddValues(false, true)
+            .Where(row => !Equals(row[0], 0) || !Equals(row[1], "large"))
+            .BuildPairwiseCombinations(seed: 42);
+
+        Assert.DoesNotContain(results, row => Equals(row.GetData()[0], 0) && Equals(row.GetData()[1], "large"));
+        Assert.Contains(results, row => Equals(row.GetData()[0], 0));
+        Assert.Contains(results, row => Equals(row.GetData()[1], "large"));
+    }
+
+    [Fact]
+    public void EnumerableOverloadsBuildRows()
+    {
+        IEnumerable<IReadOnlyList<object?>> baseRows =
+        [
+            new object?[] { 1, 2 },
+            new object?[] { 3, 4 },
+        ];
+        IEnumerable<int> values = new List<int> { 5, 6 };
+
+        IReadOnlyCollection<ITheoryDataRow> results = new CombinatorialTheoryDataBuilder()
+            .AddRows(baseRows)
+            .AddValues(values)
+            .BuildCombinations();
+
+        Assert.Equal(4, results.Count);
+        Assert.Contains(results, row => row.GetData().SequenceEqual([3, 4, 6]));
+    }
+
+    [Fact]
+    public void InputsAreSnapshotted()
+    {
+        object?[] baseRow = [1, 2];
+        int[] values = [3, 4];
+        CombinatorialTheoryDataBuilder builder = new CombinatorialTheoryDataBuilder()
+            .AddRows(baseRow)
+            .AddValues(values);
+
+        baseRow[0] = 99;
+        values[0] = 99;
+
+        Assert.Equal(
+            [[1, 2, 3], [1, 2, 4]],
+            builder.BuildCombinations().Select(row => row.GetData()));
+    }
+
+    [Fact]
+    public void AddRows_AfterAddValuesThrows()
+    {
+        CombinatorialTheoryDataBuilder builder = new CombinatorialTheoryDataBuilder().AddValues(1, 2);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => builder.AddRows([3, 4]));
+        Assert.Contains(nameof(CombinatorialTheoryDataBuilder.AddRows), exception.Message);
+    }
+
+    [Fact]
+    public void AddRows_RequiresConsistentWidth()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new CombinatorialTheoryDataBuilder().AddRows([1, 2], [3]));
+    }
+
+    [Fact]
+    public void AddRows_RequiresAtLeastOneRow()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new CombinatorialTheoryDataBuilder().AddRows(ReadOnlySpan<object?[]>.Empty));
+    }
+
+    [Fact]
+    public void AddRows_RejectsNullRows()
+    {
+        object?[] nullRow = null!;
+
+        Assert.Throws<ArgumentException>(
+            () => new CombinatorialTheoryDataBuilder().AddRows(nullRow));
+    }
+
+    [Fact]
+    public void EnumerableAddRows_RequiresAtLeastOneRow()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new CombinatorialTheoryDataBuilder().AddRows((IEnumerable<IReadOnlyList<object?>>)Array.Empty<IReadOnlyList<object?>>()));
+    }
+
+    [Fact]
+    public void EnumerableAddValues_RequiresAtLeastOneValue()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new CombinatorialTheoryDataBuilder().AddValues(Enumerable.Empty<int>()));
+    }
+
+    [Fact]
+    public void AddValues_RequiresAtLeastOneValue()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new CombinatorialTheoryDataBuilder().AddValues(ReadOnlySpan<int>.Empty));
+    }
+
+    [Fact]
+    public void BuildCombinations_RequiresExplicitRowsToMatchFinalWidth()
+    {
+        CombinatorialTheoryDataBuilder builder = new CombinatorialTheoryDataBuilder()
+            .AddValues(1, 2)
+            .AddTestCase(1, 2);
+
+        Assert.Throws<InvalidOperationException>(() => builder.BuildCombinations());
+    }
+
+    [Fact]
+    public void BuildCombinations_WithOnlyExplicitRows()
+    {
+        IReadOnlyCollection<ITheoryDataRow> results = new CombinatorialTheoryDataBuilder()
+            .AddTestCase()
+            .BuildCombinations();
+
+        Assert.Single(results);
+        Assert.Empty(results.Single().GetData());
+    }
+}


### PR DESCRIPTION
Issues #93 and #85 highlight scenarios where parameter attributes are too restrictive: callers need to preserve relationships in hand-authored rows, generate additional columns, append bespoke cases, or produce permutations. This exposes the library's generation engine for ordinary xUnit member data while keeping existing attributes as convenient built-in consumers.

## Summary

- Add span-based public APIs for exhaustive combinations, seeded pairwise covering sets, and permutations.
- Add an xUnit-oriented builder where `AddRows` establishes correlated base rows, `AddValues` adds generated columns, `Where` constrains generated cases, and `AddTestCase` appends explicit rows.
- Refactor `CombinatorialDataAttribute` and `PairwiseDataAttribute` to reuse the public index generator while preserving existing deterministic defaults, exclusions, and fresh member-data behavior.
- Document custom member-data generation, pairwise seed reproducibility, and low-level index mapping with buildable samples.

The optional seed applies only to pairwise generation: omitting it preserves the current deterministic result, while supplying and recording a seed allows callers to vary and reproduce a covering set.

## Validation

- Release build across all target frameworks
- 894 tests across net472, net8.0, and net10.0 samples
- DocFX build with warnings as errors
- NuGet pack and package compatibility validation